### PR TITLE
[SPRF-817] configures credo as dep only to test env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule HttpClients.MixProject do
       {:tesla, "~> 1.4.0"},
       {:jason, ">= 1.0.0"},
       {:goodies, github: "bcredi/goodies"},
-      {:credo, "~> 1.5", only: :test},
+      {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.13", only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule HttpClients.MixProject do
       {:tesla, "~> 1.4.0"},
       {:jason, ">= 1.0.0"},
       {:goodies, github: "bcredi/goodies"},
-      {:credo, "~> 1.5"},
+      {:credo, "~> 1.5", only: :test},
       {:excoveralls, "~> 0.13", only: :test}
     ]
   end


### PR DESCRIPTION
**Why is this change necessary?**

- When using credo as dependency only on test environent in an app that has http-clients as a dependency, we get the following error:
```ex
Dependencies have diverged:
* credo (Hex package)
  the :only option for dependency credo

  > In mix.exs:
    {:credo, "~> 1.5", [env: :prod, repo: "hexpm", hex: "credo", only: :test]}

  does not match the :only option calculated for

  > In deps/http_clients/mix.exs:
    {:credo, "~> 1.5", [env: :prod, repo: "hexpm", hex: "credo"]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```

**How does it address the issue?**

- configures credo to be a dependency only on test environment

**What side effects does this change have?**
- n/a

**Task card (link)**

- [SPRG-817](https://bcredi.atlassian.net/browse/SPRF-817)
