### PR TITLE
[SPRF-808] Add function to create proponents using underwriter`s API

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -5,12 +5,25 @@ defmodule HttpClients.Underwriter do
   alias HttpClients.Underwriter.Proponent
 
   @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
-  def create_proponent(%Tesla.Client{} = client, %Proponent{} = attrs) do
-    case Tesla.post(client, "/v1/proponents", attrs) do
-      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+  def create_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
+    case Tesla.post(client, "/v1/proponents", proponent) do
+      {:ok, %Tesla.Env{status: 201} = response} -> {:ok, build_struct(response.body["data"])}
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp build_struct(proponent) do
+    %Proponent{
+      id: proponent["id"],
+      birthdate: proponent["birthdate"],
+      email: proponent["email"],
+      cpf: proponent["cpf"],
+      name: proponent["name"],
+      mobile_phone_number: proponent["mobile_phone_number"],
+      proposal_id: proponent["proposal_id"],
+      added_by_proponent: proponent["added_by_proponent"]
+    }
   end
 
   @spec client(String.t(), String.t(), String.t()) :: Tesla.Client.t()

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -1,8 +1,39 @@
-defmodule HttpClients.CustomerManagement do
-    @moduledoc """
-    Client for Underwriter calls
-    """
-    @spec get_proponent(Tesla.Client.t(), map()) :: {:error, any} | {:ok, Tesla.Env.t()}
-    def create_proponent(%Tesla.Client{} = client, attrs) do
+defmodule HttpClients.Underwriter do
+  @moduledoc """
+  Client for Underwriter calls
+  """
+  alias HttpClients.Underwriter.Proponent
+
+  @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
+  def create_proponent(%Tesla.Client{} = client, %Proponent{} = attrs) do
+    case Tesla.post(client, "/v1/proponents", attrs) do
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
     end
+  end
+
+  @spec client(String.t(), String.t(), String.t()) :: Tesla.Client.t()
+  def client(base_url, client_id, client_secret) do
+    headers = authorization_headers(client_id, client_secret)
+
+    middleware = [
+      {Tesla.Middleware.BaseUrl, base_url},
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Headers, headers},
+      {Tesla.Middleware.Retry, delay: 1_000, max_retries: 3},
+      {Tesla.Middleware.Timeout, timeout: 15_000},
+      Tesla.Middleware.Logger,
+      Goodies.Tesla.Middleware.RequestIdForwarder
+    ]
+
+    Tesla.client(middleware)
+  end
+
+  defp authorization_headers(client_id, client_secret) do
+    [
+      {"X-Ambassador-Client-ID", client_id},
+      {"X-Ambassador-Client-Secret", client_secret}
+    ]
+  end
 end

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -1,0 +1,8 @@
+defmodule HttpClients.CustomerManagement do
+    @moduledoc """
+    Client for Underwriter calls
+    """
+    @spec get_proponent(Tesla.Client.t(), map()) :: {:error, any} | {:ok, Tesla.Env.t()}
+    def create_proponent(%Tesla.Client{} = client, attrs) do
+    end
+end

--- a/lib/http_clients/underwriter/proponent.ex
+++ b/lib/http_clients/underwriter/proponent.ex
@@ -1,0 +1,17 @@
+defmodule HttpClients.Underwriter.Proponent do
+  @moduledoc false
+  @derive Jason.Encoder
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          birthdate: String.t(),
+          email: String.t(),
+          cpf: String.t(),
+          name: String.t(),
+          mobile_phone_number: String.t(),
+          proposal_id: binary(),
+          added_by_proponent: String.t()
+        }
+
+  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent)a
+end

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -1,0 +1,70 @@
+defmodule HttpClients.UnderwriterTest do
+  use ExUnit.Case
+  import Tesla.Mock
+
+  alias HttpClients.Underwriter
+
+  @base_url "http://bcredi.com"
+  @client_id "client-id"
+  @client_secret "client-secret"
+
+  describe "client/3" do
+    test "returns a tesla client" do
+      expected_client = %Tesla.Client{
+        adapter: nil,
+        fun: nil,
+        post: [],
+        pre: [
+          {Tesla.Middleware.BaseUrl, :call, [@base_url]},
+          {Tesla.Middleware.JSON, :call, [[]]},
+          {Tesla.Middleware.Headers, :call,
+           [
+             [
+               {"X-Ambassador-Client-ID", @client_id},
+               {"X-Ambassador-Client-Secret", @client_secret}
+             ]
+           ]},
+          {Tesla.Middleware.Retry, :call, [[delay: 1000, max_retries: 3]]},
+          {Tesla.Middleware.Timeout, :call, [[timeout: 15_000]]},
+          {Tesla.Middleware.Logger, :call, [[]]},
+          {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
+        ]
+      }
+
+      client = Underwriter.client(@base_url, @client_id, @client_secret)
+      assert client == expected_client
+    end
+  end
+
+  describe "create_proponent/2" do
+    test "calls underwriter and creates proponent" do
+      proponents_url = "#{@base_url}/v1/proponents"
+
+      mock(fn %{method: :post, url: ^proponents_url} ->
+        json(%{"id" => proponent_id})
+      end)
+
+      assert {:ok, %Tesla.Env{body: response_body, status: 200}} =
+               Underwriter.create_proponent(client(), %{})
+
+      assert response_body == expected_response_body
+    end
+
+    test "returns error when the resource not exists" do
+      proponent_id = UUID.uuid4()
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :get, url: ^proponents_url} ->
+        %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not Found"}}}
+      end)
+
+      assert {:error, %Tesla.Env{body: response_body, status: 404}} =
+               CustomerManagement.get_proponent(client(), proponent_id)
+
+      expected_response_body = %{"errors" => %{"detail" => "Not Found"}}
+      assert response_body == expected_response_body
+    end
+  end
+
+  defp client, do: Tesla.client([{Tesla.Middleware.BaseUrl, @base_url}, Tesla.Middleware.JSON])
+end

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -11,29 +11,25 @@ defmodule HttpClients.UnderwriterTest do
 
   describe "client/3" do
     test "returns a tesla client" do
-      expected_client = %Tesla.Client{
-        adapter: nil,
-        fun: nil,
-        post: [],
-        pre: [
-          {Tesla.Middleware.BaseUrl, :call, [@base_url]},
-          {Tesla.Middleware.JSON, :call, [[]]},
-          {Tesla.Middleware.Headers, :call,
+      expected_configs = [
+        {Tesla.Middleware.BaseUrl, :call, [@base_url]},
+        {Tesla.Middleware.JSON, :call, [[]]},
+        {Tesla.Middleware.Headers, :call,
+         [
            [
-             [
-               {"X-Ambassador-Client-ID", @client_id},
-               {"X-Ambassador-Client-Secret", @client_secret}
-             ]
-           ]},
-          {Tesla.Middleware.Retry, :call, [[delay: 1000, max_retries: 3]]},
-          {Tesla.Middleware.Timeout, :call, [[timeout: 15_000]]},
-          {Tesla.Middleware.Logger, :call, [[]]},
-          {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
-        ]
-      }
+             {"X-Ambassador-Client-ID", @client_id},
+             {"X-Ambassador-Client-Secret", @client_secret}
+           ]
+         ]},
+        {Tesla.Middleware.Retry, :call, [[delay: 1000, max_retries: 3]]},
+        {Tesla.Middleware.Timeout, :call, [[timeout: 15_000]]},
+        {Tesla.Middleware.Logger, :call, [[]]},
+        {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
+      ]
 
       client = Underwriter.client(@base_url, @client_id, @client_secret)
-      assert client == expected_client
+      assert %Tesla.Client{} = client
+      assert client.pre == expected_configs
     end
   end
 


### PR DESCRIPTION
**Why is this change necessary?**

- We need to create proponents through a POST request to the underwriter service.

**How does it address the issue?**

- Implements the create_proponent method
- Creates underwriter client
- Tests

**What side effects does this change have?**

- N/A

**Task card (link)**

- [[http-clients] Suportar POST /proponents no client do Underwriter](https://bcredi.atlassian.net/browse/SPRF-808)
