### PR TITLE
[SPRF-827] Add get_proponent for underwriter client

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -4,6 +4,15 @@ defmodule HttpClients.Underwriter do
   """
   alias HttpClients.Underwriter.Proponent
 
+  @spec get_proponent(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
+  def get_proponent(%Tesla.Client{} = client, proponent_id) do
+    case Tesla.get(client, "/v1/proponents/#{proponent_id}") do
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Proponent.t()}
   def create_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.post(client, "/v1/proponents", proponent) do

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -66,5 +66,37 @@ defmodule HttpClients.UnderwriterTest do
     end
   end
 
+  describe "get_proponent/2" do
+    test "returns a proponent" do
+      proponent_id = UUID.uuid4()
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :get, url: ^proponents_url} ->
+        json(%{"id" => proponent_id})
+      end)
+
+      assert {:ok, %Tesla.Env{body: response_body, status: 200}} =
+               Underwriter.get_proponent(client(), proponent_id)
+
+      expected_response_body = %{"id" => proponent_id}
+      assert response_body == expected_response_body
+    end
+
+    test "returns error when the resource not exists" do
+      proponent_id = UUID.uuid4()
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :get, url: ^proponents_url} ->
+        %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not Found"}}}
+      end)
+
+      assert {:error, %Tesla.Env{body: response_body, status: 404}} =
+               Underwriter.get_proponent(client(), proponent_id)
+
+      expected_response_body = %{"errors" => %{"detail" => "Not Found"}}
+      assert response_body == expected_response_body
+    end
+  end
+
   defp client, do: Tesla.client([{Tesla.Middleware.BaseUrl, @base_url}, Tesla.Middleware.JSON])
 end


### PR DESCRIPTION
**Why is this change necessary?**
- We need to consume underwriter API to get the proponent.

**How does it address the issue?**
- Create get_proponent for Underwriter client

**What side effects does this change have?**
- n/a

**Task card (link)**
- [SPRF-827](https://bcredi.atlassian.net/browse/SPRF-827)
