### PR TITLE
[SPRF-838] adds serial_id to proponent struct

### DIFF
--- a/lib/http_clients/underwriter/proponent.ex
+++ b/lib/http_clients/underwriter/proponent.ex
@@ -8,9 +8,10 @@ defmodule HttpClients.Underwriter.Proponent do
           cpf: String.t(),
           name: String.t(),
           proposal_id: binary(),
-          added_by_proponent: String.t()
+          added_by_proponent: String.t(),
+          serial_id: integer()
         }
 
   @derive Jason.Encoder
-  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent)a
+  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent serial_id)a
 end


### PR DESCRIPTION
**Why is this change necessary?**

- To retrieve the proponent`s serial_id from underwriter

**How does it address the issue?**

- Adds serial_id to the struct

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-838](https://bcredi.atlassian.net/browse/SPRF-838)