### PR TITLE
[SPRF-840] add base_date opts to Neurotech.compute_bacen_score/5

### DIFF
--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -85,7 +85,7 @@ defmodule HttpClients.Neurotech do
   defp put_base_date(inputs, base_date)
   defp put_base_date(inputs, nil), do: inputs
 
-  defp put_base_date(inputs, base_date) do
+  defp put_base_date(inputs, %Date{} = base_date) do
     base_date = Calendar.strftime(base_date, "%d/%m/%Y")
     Map.put(inputs, "PROP_BACEN_DATA_BASE", base_date)
   end

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -54,12 +54,7 @@ defmodule HttpClients.NeurotechTest do
   describe "compute_bacen_score/2" do
     test "returns score when the request succeeds" do
       response_body = bacen_response(:success)
-
-      mock(fn %{url: "/submit", method: :post, body: body} ->
-        assert not String.match?(body, ~r/PROP_BACEN_DATA_BASE/)
-        json(response_body)
-      end)
-
+      mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
       person = %Neurotech.Person{cpf: "65661563051"}
 
       expected_analysis = %Score{
@@ -82,14 +77,13 @@ defmodule HttpClients.NeurotechTest do
       end)
 
       person = %Neurotech.Person{cpf: "65661563051"}
+      opts = [base_date: ~D[2017-10-01]]
 
       expected_analysis = %Score{
         score: 444,
         positive_analysis: "- Sem registro de vencidos no histórico.\r\n",
         negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
       }
-
-      opts = [base_date: ~D[2017-10-01]]
 
       assert {:ok, ^expected_analysis} =
                Neurotech.compute_bacen_score(


### PR DESCRIPTION
**Why is this change necessary?**

- To support the homologation environment of SCR Bacen.

**How does it address the issue?**

- Add base_date opts to Neurotech.compute_bacen_score/5.

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-840](https://bcredi.atlassian.net/browse/SPRF-840)
