### PR TITLE
[SPRF-843] using Calendar to format date

### DIFF
--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -16,7 +16,8 @@ defmodule HttpClients.Neurotech do
     inputs = %{
       "PROP_POLITICA" => "VALIDACAO_IDENTIDADE",
       "PROP_VALIDACAO_IDENTIDADE_CPF" => person.cpf,
-      "PROP_VALIDACAO_IDENTIDADE_DATA_NASCIMENTO" => format_date(person.birthdate),
+      "PROP_VALIDACAO_IDENTIDADE_DATA_NASCIMENTO" =>
+        Calendar.strftime(person.birthdate, "%d/%m/%Y"),
       "PROP_VALIDACAO_IDENTIDADE_NOME" => person.name
     }
 
@@ -36,11 +37,6 @@ defmodule HttpClients.Neurotech do
       {:error, reason} ->
         {:error, reason}
     end
-  end
-
-  defp format_date(%Date{} = date) do
-    month = if date.month < 10, do: "0#{date.month}", else: date.month
-    "#{date.day}/#{month}/#{date.year}"
   end
 
   defp approved?(status), do: status == "APROVADO"


### PR DESCRIPTION
**Why is this change necessary?**

- Our function to format date is not ideal and might be wrong. Using Calendar to parse date instead

**How does it address the issue?**

- Uses Calendar to parse date 

**What side effects does this change have?**

- N/A

**Task card (link)**

- [corrigir formatação de data](https://bcredi.atlassian.net/browse/SPRF-843)
