### PR TITLE
[SPRF-863] add Underwriter.update_proponent/2

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -34,6 +34,16 @@ defmodule HttpClients.Underwriter do
     }
   end
 
+  @spec update_proponent_email(Tesla.Client.t(), Proponent.t()) ::
+          {:error, any} | {:ok, Proponent.t()}
+  def update_proponent_email(%Tesla.Client{} = client, %Proponent{} = proponent) do
+    case Tesla.patch(client, "/v1/proponents/#{proponent.id}", proponent) do
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, build_struct(response.body["data"])}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec client(String.t(), String.t(), String.t()) :: Tesla.Client.t()
   def client(base_url, client_id, client_secret) do
     headers = authorization_headers(client_id, client_secret)

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -34,9 +34,9 @@ defmodule HttpClients.Underwriter do
     }
   end
 
-  @spec update_proponent_email(Tesla.Client.t(), Proponent.t()) ::
+  @spec update_proponent(Tesla.Client.t(), Proponent.t()) ::
           {:error, any} | {:ok, Proponent.t()}
-  def update_proponent_email(%Tesla.Client{} = client, %Proponent{} = proponent) do
+  def update_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.patch(client, "/v1/proponents/#{proponent.id}", proponent) do
       {:ok, %Tesla.Env{status: 200} = response} -> {:ok, build_struct(response.body["data"])}
       {:ok, %Tesla.Env{} = response} -> {:error, response}

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -98,5 +98,50 @@ defmodule HttpClients.UnderwriterTest do
     end
   end
 
+  describe "update_proponent_email/2" do
+    test "returns a proponent" do
+      proponent_id = UUID.uuid4()
+      email = "some@email.com"
+      proponent = %Proponent{id: proponent_id, email: email}
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :patch, url: ^proponents_url} ->
+        %Tesla.Env{status: 200, body: %{"data" => %{"id" => proponent_id, "email" => email}}}
+      end)
+
+      assert {:ok, ^proponent} = Underwriter.update_proponent_email(client(), proponent)
+    end
+
+    test "returns error when the resource not exists" do
+      proponent_id = UUID.uuid4()
+      email = "some@email.com"
+      proponent = %Proponent{id: proponent_id, email: email}
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :patch, url: ^proponents_url} ->
+        %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not Found"}}}
+      end)
+
+      assert {:error, %Tesla.Env{body: response_body, status: 404}} =
+               Underwriter.update_proponent_email(client(), proponent)
+
+      expected_response_body = %{"errors" => %{"detail" => "Not Found"}}
+      assert response_body == expected_response_body
+    end
+
+    test "returns error when email is invalid" do
+      proponent_id = UUID.uuid4()
+      email = "invalid#email.com"
+      proponent = %Proponent{id: proponent_id, email: email}
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      response_body = %{"errors" => %{"email" => ["has invalid format"]}}
+      mock(fn %{method: :patch, url: ^proponents_url} -> json(response_body, status: 422) end)
+
+      assert {:error, expected_response} = Underwriter.update_proponent_email(client(), proponent)
+      assert %Tesla.Env{body: ^response_body, status: 422} = expected_response
+    end
+  end
+
   defp client, do: Tesla.client([{Tesla.Middleware.BaseUrl, @base_url}, Tesla.Middleware.JSON])
 end

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -98,7 +98,7 @@ defmodule HttpClients.UnderwriterTest do
     end
   end
 
-  describe "update_proponent_email/2" do
+  describe "update_proponent/2" do
     test "returns a proponent" do
       proponent_id = UUID.uuid4()
       email = "some@email.com"
@@ -109,7 +109,7 @@ defmodule HttpClients.UnderwriterTest do
         %Tesla.Env{status: 200, body: %{"data" => %{"id" => proponent_id, "email" => email}}}
       end)
 
-      assert {:ok, ^proponent} = Underwriter.update_proponent_email(client(), proponent)
+      assert {:ok, ^proponent} = Underwriter.update_proponent(client(), proponent)
     end
 
     test "returns error when the resource not exists" do
@@ -123,7 +123,7 @@ defmodule HttpClients.UnderwriterTest do
       end)
 
       assert {:error, %Tesla.Env{body: response_body, status: 404}} =
-               Underwriter.update_proponent_email(client(), proponent)
+               Underwriter.update_proponent(client(), proponent)
 
       expected_response_body = %{"errors" => %{"detail" => "Not Found"}}
       assert response_body == expected_response_body
@@ -138,7 +138,7 @@ defmodule HttpClients.UnderwriterTest do
       response_body = %{"errors" => %{"email" => ["has invalid format"]}}
       mock(fn %{method: :patch, url: ^proponents_url} -> json(response_body, status: 422) end)
 
-      assert {:error, expected_response} = Underwriter.update_proponent_email(client(), proponent)
+      assert {:error, expected_response} = Underwriter.update_proponent(client(), proponent)
       assert %Tesla.Env{body: ^response_body, status: 422} = expected_response
     end
   end


### PR DESCRIPTION
**Why is this change necessary?**

- To support the new "Update Proponent" route on Underwriter.

**How does it address the issue?**

- Add `Underwriter.update_proponent/2`.

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-863](https://bcredi.atlassian.net/browse/SPRF-863)
