### PR TITLE
fix HttpClients.Underwriter.remove_proponent/2 spec

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -44,10 +44,10 @@ defmodule HttpClients.Underwriter do
     end
   end
 
-  @spec remove_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, nil}
+  @spec remove_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | :ok
   def remove_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.delete(client, "/v1/proponents/#{proponent.id}") do
-      {:ok, %Tesla.Env{status: 204}} -> {:ok, nil}
+      {:ok, %Tesla.Env{status: 204}} -> :ok
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -44,8 +44,7 @@ defmodule HttpClients.Underwriter do
     end
   end
 
-  @spec remove_proponent(Tesla.Client.t(), Proponent.t()) ::
-          {:error, any} | {:ok, Proponent.t()}
+  @spec remove_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, nil}
   def remove_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.delete(client, "/v1/proponents/#{proponent.id}") do
       {:ok, %Tesla.Env{status: 204}} -> {:ok, nil}

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -153,7 +153,7 @@ defmodule HttpClients.UnderwriterTest do
         %Tesla.Env{status: 204, body: %{}}
       end)
 
-      assert {:ok, nil} = Underwriter.remove_proponent(client(), proponent)
+      assert :ok = Underwriter.remove_proponent(client(), proponent)
     end
 
     test "returns error when the proponent doesn't exist" do


### PR DESCRIPTION
**Why is this change necessary?**

- To fix #10 new function.

**How does it address the issue?**

- Change spec to `:ok`.

**What side effects does this change have?**

- N/A