### PR TITLE
[SPRF-1014] add "GET /v1/proponents/:id" route for CustomerManagement

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
 
     steps:
       - uses: actions/checkout@v2
@@ -22,13 +24,15 @@ jobs:
       - name: Restore dependencies cache
         uses: actions/cache@v2
         with:
-          path: deps
+          path: |
+            deps
+            _build
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
       - name: Install dependencies
         run: mix deps.get
       - name: Run tests
-        run: MIX_ENV=test mix coveralls
+        run: mix coveralls
       - name: Run credo
         run: mix credo --strict
       - name: Run format

--- a/lib/http_clients/customer_management.ex
+++ b/lib/http_clients/customer_management.ex
@@ -12,6 +12,15 @@ defmodule HttpClients.CustomerManagement do
     end
   end
 
+  @spec get_proponent(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
+  def get_proponent(%Tesla.Client{} = client, proponent_id) do
+    case Tesla.get(client, "/v1/proponents/#{proponent_id}") do
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec client(String.t(), String.t(), String.t()) :: Tesla.Client.t()
   def client(base_url, client_id, client_secret) do
     headers = authorization_headers(client_id, client_secret)

--- a/test/http_clients/customer_management_test.exs
+++ b/test/http_clients/customer_management_test.exs
@@ -51,7 +51,7 @@ defmodule HttpClients.CustomerManagementTest do
       assert response_body == %{"id" => proposal_id}
     end
 
-    test "returns error when the resource not exists" do
+    test "returns an error when proposal doesn't exist" do
       proposal_id = UUID.uuid4()
       proposals_url = "#{@base_url}/v1/proposals/#{proposal_id}"
 
@@ -61,6 +61,36 @@ defmodule HttpClients.CustomerManagementTest do
 
       assert {:error, %Tesla.Env{body: response_body, status: 404}} =
                CustomerManagement.get_proposal(client(), proposal_id)
+
+      assert response_body == %{"errors" => %{"detail" => "Not Found"}}
+    end
+  end
+
+  describe "get_proponent/2" do
+    test "returns a proponent" do
+      proponent_id = UUID.uuid4()
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :get, url: ^proponents_url} ->
+        json(%{"id" => proponent_id})
+      end)
+
+      assert {:ok, %Tesla.Env{body: response_body, status: 200}} =
+               CustomerManagement.get_proponent(client(), proponent_id)
+
+      assert response_body == %{"id" => proponent_id}
+    end
+
+    test "returns an error when proponent doesn't exist" do
+      proponent_id = UUID.uuid4()
+      proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
+
+      mock(fn %{method: :get, url: ^proponents_url} ->
+        %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not Found"}}}
+      end)
+
+      assert {:error, %Tesla.Env{body: response_body, status: 404}} =
+               CustomerManagement.get_proponent(client(), proponent_id)
 
       assert response_body == %{"errors" => %{"detail" => "Not Found"}}
     end


### PR DESCRIPTION
**Why is this change necessary?**

- To support new Main Proponent identity validation flow. PoliciesExecutor needs to retrieve the proposal_id from a proponent_id.

**How does it address the issue?**

- Add `get_proponent/2` on `HttpClients.CustomerManagement`;
- Fix CI cache :rocket: 

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-1014](https://bcredi.atlassian.net/browse/SPRF-1014)
