### PR TITLE
[SPRF-979] Fix HttpClients.Neurotech.Request timeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # HttpClients
 
-**TODO: Add description**
+API clients for BCreditas platform.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `http_clients` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `http_clients` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:http_clients, "~> 0.1.0"}
+    {:http_clients, github: "bcredi/http-clients", branch: "main"}
   ]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/http_clients](https://hexdocs.pm/http_clients).
+Add Hackney as Tesla default adapter in `config.exs`:
 
+```elixir
+config :tesla, adapter: Tesla.Adapter.Hackney
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HttpClients
 
-API clients for BCreditas platform.
+API clients for Bcredi platform.
 
 ## Installation
 

--- a/lib/http_clients/neurotech/request.ex
+++ b/lib/http_clients/neurotech/request.ex
@@ -36,7 +36,7 @@ defmodule HttpClients.Neurotech.Request do
 
     request = build_body(request)
 
-    Tesla.post(client, "/submit", request, client_opts)
+    Tesla.post(client, "/submit", request, opts: client_opts)
   end
 
   defp build_inputs(%{} = inputs) when inputs != %{},

--- a/test/http_clients/neurotech/request_test.exs
+++ b/test/http_clients/neurotech/request_test.exs
@@ -19,7 +19,11 @@ defmodule HttpClients.Neurotech.RequestTest do
       }
 
       neurotech_response = bacen_response(:success)
-      mock(fn %{url: "/submit", method: :post} -> json(neurotech_response) end)
+      expected_opts = [adapter: [ssl_options: [verify: :verify_none], recv_timeout: 600_000]]
+
+      mock(fn %{url: "/submit", method: :post, opts: ^expected_opts} ->
+        json(neurotech_response)
+      end)
 
       assert {:ok, %Tesla.Env{status: 200, body: %{"StatusCode" => "0100"}}} =
                Request.submit(client(), request)


### PR DESCRIPTION
**Why is this change necessary?**

- To support running identity validation for Main Proponent. This fix is needed to support the Neurotech client with Hackney adapter.

**How does it address the issue?**

- Fix Tesla `opts` on `HttpClients.Neurotech.Request`;
- Improve README.md

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-979](https://bcredi.atlassian.net/browse/SPRF-979)