### PR TITLE
[SPRF-968] - Add scr authorizer client and proponent authorization

### DIFF
--- a/lib/http_clients/scr_authorizer.ex
+++ b/lib/http_clients/scr_authorizer.ex
@@ -1,0 +1,52 @@
+defmodule HttpClients.ScrAuthorizer do
+  @moduledoc """
+  Client for SCR Authorizer calls
+  """
+  alias HttpClients.ScrAuthorizer.ProponentAuthorization
+
+  @spec create_proponent_authorization(Tesla.Client.t(), ProponentAuthorization.t()) ::
+          {:error, any} | {:ok, Proponent.t()}
+  def create_proponent_authorization(
+        %Tesla.Client{} = client,
+        %ProponentAuthorization{} = authorization
+      ) do
+    case Tesla.post(client, "/v1/proponent-authorizations", authorization) do
+      {:ok, %Tesla.Env{status: 201} = response} -> {:ok, build_struct(response.body["data"])}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp build_struct(proponent_authorization) do
+    %ProponentAuthorization{
+      id: proponent_authorization["id"],
+      proponent_id: proponent_authorization["proponent_id"],
+      user_agent: proponent_authorization["user_agent"],
+      ip: proponent_authorization["ip"]
+    }
+  end
+
+  @spec client(String.t(), String.t(), String.t()) :: Tesla.Client.t()
+  def client(base_url, client_id, client_secret) do
+    headers = authorization_headers(client_id, client_secret)
+
+    middleware = [
+      {Tesla.Middleware.BaseUrl, base_url},
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Headers, headers},
+      {Tesla.Middleware.Retry, delay: 1_000, max_retries: 3},
+      {Tesla.Middleware.Timeout, timeout: 15_000},
+      Tesla.Middleware.Logger,
+      Goodies.Tesla.Middleware.RequestIdForwarder
+    ]
+
+    Tesla.client(middleware)
+  end
+
+  defp authorization_headers(client_id, client_secret) do
+    [
+      {"X-Ambassador-Client-ID", client_id},
+      {"X-Ambassador-Client-Secret", client_secret}
+    ]
+  end
+end

--- a/lib/http_clients/scr_authorizer.ex
+++ b/lib/http_clients/scr_authorizer.ex
@@ -11,18 +11,23 @@ defmodule HttpClients.ScrAuthorizer do
         %ProponentAuthorization{} = authorization
       ) do
     case Tesla.post(client, "/v1/proponent-authorizations", authorization) do
-      {:ok, %Tesla.Env{status: 201} = response} -> {:ok, build_struct(response.body["data"])}
-      {:ok, %Tesla.Env{} = response} -> {:error, response}
-      {:error, reason} -> {:error, reason}
+      {:ok, %Tesla.Env{status: 201} = response} ->
+        {:ok, build_proponent_authorization(response.body["data"])}
+
+      {:ok, %Tesla.Env{} = response} ->
+        {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp build_struct(proponent_authorization) do
+  defp build_proponent_authorization(authorization) do
     %ProponentAuthorization{
-      id: proponent_authorization["id"],
-      proponent_id: proponent_authorization["proponent_id"],
-      user_agent: proponent_authorization["user_agent"],
-      ip: proponent_authorization["ip"]
+      id: authorization["id"],
+      proponent_id: authorization["proponent_id"],
+      user_agent: authorization["user_agent"],
+      ip: authorization["ip"]
     }
   end
 

--- a/lib/http_clients/scr_authorizer/proponent_authorization.ex
+++ b/lib/http_clients/scr_authorizer/proponent_authorization.ex
@@ -1,0 +1,14 @@
+defmodule HttpClients.ScrAuthorizer.ProponentAuthorization do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          id: UUID.t(),
+          proponent_id: UUID.t(),
+          user_agent: String.t(),
+          ip: String.t(),
+          term_of_use_document: binary()
+        }
+
+  @derive Jason.Encoder
+  defstruct ~w(id proponent_id user_agent ip term_of_use_document)a
+end

--- a/test/http_clients/scr_authorizer_test.exs
+++ b/test/http_clients/scr_authorizer_test.exs
@@ -1,0 +1,84 @@
+defmodule HttpClients.ScrAuthorizerTest do
+  use ExUnit.Case
+  import Tesla.Mock
+
+  alias HttpClients.ScrAuthorizer
+  alias HttpClients.ScrAuthorizer.ProponentAuthorization
+
+  @base_url "http://bcredi.com"
+  @client_id "client-id"
+  @client_secret "client-secret"
+
+  describe "client/3" do
+    test "returns a tesla client" do
+      expected_configs = [
+        {Tesla.Middleware.BaseUrl, :call, [@base_url]},
+        {Tesla.Middleware.JSON, :call, [[]]},
+        {Tesla.Middleware.Headers, :call,
+         [
+           [
+             {"X-Ambassador-Client-ID", @client_id},
+             {"X-Ambassador-Client-Secret", @client_secret}
+           ]
+         ]},
+        {Tesla.Middleware.Retry, :call, [[delay: 1000, max_retries: 3]]},
+        {Tesla.Middleware.Timeout, :call, [[timeout: 15_000]]},
+        {Tesla.Middleware.Logger, :call, [[]]},
+        {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
+      ]
+
+      client = ScrAuthorizer.client(@base_url, @client_id, @client_secret)
+      assert %Tesla.Client{} = client
+      assert client.pre == expected_configs
+    end
+  end
+
+  describe "create_proponent_authorization/2" do
+    @term_of_use_document %{
+      content_type: "application/pdf",
+      filename: "authorization-09a485d8-b952-4398-b303-4830ff205e05.pdf",
+      path: "test/support/pdf_to_upload_test.pdf"
+    }
+    @proponent_authorization %ProponentAuthorization{
+      proponent_id: UUID.uuid4(),
+      user_agent: "some user agent",
+      ip: "8.8.8.8",
+      term_of_use_document: @term_of_use_document
+    }
+
+    test "creates proponent authorization" do
+      authorization_id = UUID.uuid4()
+      proponent_authorization_url = "#{@base_url}/v1/proponent-authorizations"
+
+      expected_authorization =
+        @proponent_authorization
+        |> Map.put(:id, authorization_id)
+        |> Map.put(:term_of_use_document, nil)
+
+      mock(fn %{method: :post, url: ^proponent_authorization_url} ->
+        json(%{data: expected_authorization}, status: 201)
+      end)
+
+      assert {:ok, ^expected_authorization} =
+               ScrAuthorizer.create_proponent_authorization(client(), @proponent_authorization)
+    end
+
+    test "returns error when authorization was not created" do
+      proponent_authorization_url = "#{@base_url}/v1/proponent-authorizations"
+      response_body = %{"errors" => %{"ip" => "can't be blank"}}
+
+      mock(fn %{method: :post, url: ^proponent_authorization_url} ->
+        json(response_body, status: 422)
+      end)
+
+      authorization_without_ip = Map.put(@proponent_authorization, :ip, nil)
+
+      assert {:error, expected_response} =
+               ScrAuthorizer.create_proponent_authorization(client(), authorization_without_ip)
+
+      assert %Tesla.Env{body: ^response_body, status: 422} = expected_response
+    end
+  end
+
+  defp client, do: Tesla.client([{Tesla.Middleware.BaseUrl, @base_url}, Tesla.Middleware.JSON])
+end

--- a/test/http_clients/scr_authorizer_test.exs
+++ b/test/http_clients/scr_authorizer_test.exs
@@ -27,9 +27,10 @@ defmodule HttpClients.ScrAuthorizerTest do
         {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
       ]
 
-      client = ScrAuthorizer.client(@base_url, @client_id, @client_secret)
-      assert %Tesla.Client{} = client
-      assert client.pre == expected_configs
+      assert %Tesla.Client{pre: configs} =
+               ScrAuthorizer.client(@base_url, @client_id, @client_secret)
+
+      assert configs == expected_configs
     end
   end
 

--- a/test/http_clients/scr_authorizer_test.exs
+++ b/test/http_clients/scr_authorizer_test.exs
@@ -59,8 +59,8 @@ defmodule HttpClients.ScrAuthorizerTest do
         json(%{data: expected_authorization}, status: 201)
       end)
 
-      assert {:ok, ^expected_authorization} =
-               ScrAuthorizer.create_proponent_authorization(client(), @proponent_authorization)
+      assert ScrAuthorizer.create_proponent_authorization(client(), @proponent_authorization) ==
+               {:ok, expected_authorization}
     end
 
     test "returns error when authorization was not created" do


### PR DESCRIPTION
**Why is this change necessary?**

- We need to create proponent authorizations through a POST request to the SCR Authorizer service.

**How does it address the issue?**

- create %ProponentAuthorization{};
- create SCR Authorizer client;

**What side effects does this change have?**

- N/A

**Task card (link)**

- [[http-clients] rota POST /v1/proponent_authorizations do scr-authorizer e documentar](https://bcredi.atlassian.net/browse/SPRF-968)
