### PR TITLE
[ORG-1782] Add "PUT /v1/proposals/:id" route for Underwriter

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -58,6 +58,9 @@ defmodule HttpClients.Underwriter do
     case Tesla.put(client, "/v1/proposals/#{proposal.id}", proposal) do
       {:ok, %Tesla.Env{status: 200} = response} ->
         {:ok, build_proposal_struct(response.body["data"])}
+
+      {:ok, %Tesla.Env{} = response} ->
+        {:error, response}
     end
   end
 

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -61,6 +61,9 @@ defmodule HttpClients.Underwriter do
 
       {:ok, %Tesla.Env{} = response} ->
         {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -16,31 +16,29 @@ defmodule HttpClients.Underwriter do
   @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Proponent.t()}
   def create_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.post(client, "/v1/proponents", proponent) do
-      {:ok, %Tesla.Env{status: 201} = response} -> {:ok, build_struct(response.body["data"])}
-      {:ok, %Tesla.Env{} = response} -> {:error, response}
-      {:error, reason} -> {:error, reason}
-    end
-  end
+      {:ok, %Tesla.Env{status: 201} = response} ->
+        {:ok, build_proponent_struct(response.body["data"])}
 
-  defp build_struct(proponent) do
-    %Proponent{
-      id: proponent["id"],
-      birthdate: proponent["birthdate"],
-      email: proponent["email"],
-      cpf: proponent["cpf"],
-      name: proponent["name"],
-      proposal_id: proponent["proposal_id"],
-      added_by_proponent: proponent["added_by_proponent"]
-    }
+      {:ok, %Tesla.Env{} = response} ->
+        {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @spec update_proponent(Tesla.Client.t(), Proponent.t()) ::
           {:error, any} | {:ok, Proponent.t()}
   def update_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.patch(client, "/v1/proponents/#{proponent.id}", proponent) do
-      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, build_struct(response.body["data"])}
-      {:ok, %Tesla.Env{} = response} -> {:error, response}
-      {:error, reason} -> {:error, reason}
+      {:ok, %Tesla.Env{status: 200} = response} ->
+        {:ok, build_proponent_struct(response.body["data"])}
+
+      {:ok, %Tesla.Env{} = response} ->
+        {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -51,6 +49,18 @@ defmodule HttpClients.Underwriter do
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp build_proponent_struct(proponent) do
+    %Proponent{
+      id: proponent["id"],
+      birthdate: proponent["birthdate"],
+      email: proponent["email"],
+      cpf: proponent["cpf"],
+      name: proponent["name"],
+      proposal_id: proponent["proposal_id"],
+      added_by_proponent: proponent["added_by_proponent"]
+    }
   end
 
   @spec update_proposal(Tesla.Client.t(), Proposal.t()) :: {:error, any} | {:ok, Proposal.t()}

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -16,29 +16,18 @@ defmodule HttpClients.Underwriter do
   @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Proponent.t()}
   def create_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.post(client, "/v1/proponents", proponent) do
-      {:ok, %Tesla.Env{status: 201} = response} ->
-        {:ok, build_proponent_struct(response.body["data"])}
-
-      {:ok, %Tesla.Env{} = response} ->
-        {:error, response}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, %Tesla.Env{status: 201} = response} -> {:ok, build_proponent(response.body["data"])}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  @spec update_proponent(Tesla.Client.t(), Proponent.t()) ::
-          {:error, any} | {:ok, Proponent.t()}
+  @spec update_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Proponent.t()}
   def update_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.patch(client, "/v1/proponents/#{proponent.id}", proponent) do
-      {:ok, %Tesla.Env{status: 200} = response} ->
-        {:ok, build_proponent_struct(response.body["data"])}
-
-      {:ok, %Tesla.Env{} = response} ->
-        {:error, response}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, build_proponent(response.body["data"])}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -51,7 +40,7 @@ defmodule HttpClients.Underwriter do
     end
   end
 
-  defp build_proponent_struct(proponent) do
+  defp build_proponent(proponent) do
     %Proponent{
       id: proponent["id"],
       birthdate: proponent["birthdate"],
@@ -66,18 +55,13 @@ defmodule HttpClients.Underwriter do
   @spec update_proposal(Tesla.Client.t(), Proposal.t()) :: {:error, any} | {:ok, Proposal.t()}
   def update_proposal(%Tesla.Client{} = client, %Proposal{} = proposal) do
     case Tesla.put(client, "/v1/proposals/#{proposal.id}", proposal) do
-      {:ok, %Tesla.Env{status: 200} = response} ->
-        {:ok, build_proposal_struct(response.body["data"])}
-
-      {:ok, %Tesla.Env{} = response} ->
-        {:error, response}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, build_proposal(response.body["data"])}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp build_proposal_struct(proposal) do
+  defp build_proposal(proposal) do
     %Proposal{
       id: proposal["id"],
       sales_stage: proposal["sales_stage"],

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -2,7 +2,7 @@ defmodule HttpClients.Underwriter do
   @moduledoc """
   Client for Underwriter calls
   """
-  alias HttpClients.Underwriter.Proponent
+  alias HttpClients.Underwriter.{Proponent, Proposal}
 
   @spec get_proponent(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
   def get_proponent(%Tesla.Client{} = client, proponent_id) do
@@ -51,6 +51,22 @@ defmodule HttpClients.Underwriter do
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  @spec update_proposal(Tesla.Client.t(), Proposal.t()) :: {:error, any} | {:ok, Proposal.t()}
+  def update_proposal(%Tesla.Client{} = client, %Proposal{} = proposal) do
+    case Tesla.put(client, "/v1/proposals/#{proposal.id}", proposal) do
+      {:ok, %Tesla.Env{status: 200} = response} ->
+        {:ok, build_proposal_struct(response.body["data"])}
+    end
+  end
+
+  defp build_proposal_struct(proposal) do
+    %Proposal{
+      id: proposal["id"],
+      sales_stage: proposal["sales_stage"],
+      lost_reason: proposal["lost_reason"]
+    }
   end
 
   @spec client(String.t(), String.t(), String.t()) :: Tesla.Client.t()

--- a/lib/http_clients/underwriter/proposal.ex
+++ b/lib/http_clients/underwriter/proposal.ex
@@ -1,0 +1,12 @@
+defmodule HttpClients.Underwriter.Proposal do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          sales_stage: String.t(),
+          lost_reason: String.t()
+        }
+
+  @derive Jason.Encoder
+  defstruct ~w(id sales_stage lost_reason)a
+end

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -188,6 +188,18 @@ defmodule HttpClients.UnderwriterTest do
 
       assert {:ok, ^proposal} = Underwriter.update_proposal(client(), proposal)
     end
+
+    test "returns error when payload is invalid" do
+      proposal_id = UUID.uuid4()
+      proposal = %Proposal{id: proposal_id}
+      proposal_url = "#{@base_url}/v1/proposals/#{proposal_id}"
+
+      response_body = %{"errors" => %{"sales_stage" => ["can't be blank"]}}
+      mock(fn %{method: :put, url: ^proposal_url} -> json(response_body, status: 422) end)
+
+      assert {:error, expected_response} = Underwriter.update_proposal(client(), proposal)
+      assert %Tesla.Env{body: ^response_body, status: 422} = expected_response
+    end
   end
 
   defp client, do: Tesla.client([{Tesla.Middleware.BaseUrl, @base_url}, Tesla.Middleware.JSON])

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -3,7 +3,7 @@ defmodule HttpClients.UnderwriterTest do
   import Tesla.Mock
 
   alias HttpClients.Underwriter
-  alias HttpClients.Underwriter.Proponent
+  alias HttpClients.Underwriter.{Proponent, Proposal}
 
   @base_url "http://bcredi.com"
   @client_id "client-id"
@@ -169,6 +169,24 @@ defmodule HttpClients.UnderwriterTest do
                Underwriter.remove_proponent(client(), proponent)
 
       assert response_body == %{"errors" => %{"detail" => "Not Found"}}
+    end
+  end
+
+  describe "update_proposal/2" do
+    test "returns a proposal" do
+      proposal_id = UUID.uuid4()
+      sales_stage = "qualified"
+      proposal = %Proposal{id: proposal_id, sales_stage: sales_stage}
+      proposal_url = "#{@base_url}/v1/proposals/#{proposal_id}"
+
+      mock(fn %{method: :put, url: ^proposal_url} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{"data" => %{"id" => proposal_id, "sales_stage" => sales_stage}}
+        }
+      end)
+
+      assert {:ok, ^proposal} = Underwriter.update_proposal(client(), proposal)
     end
   end
 

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -186,7 +186,7 @@ defmodule HttpClients.UnderwriterTest do
         }
       end)
 
-      assert {:ok, ^proposal} = Underwriter.update_proposal(client(), proposal)
+      assert Underwriter.update_proposal(client(), proposal) == {:ok, proposal}
     end
 
     test "returns error when payload is invalid" do
@@ -207,11 +207,9 @@ defmodule HttpClients.UnderwriterTest do
       proposal = %Proposal{id: proposal_id, sales_stage: sales_stage}
       proposal_url = "#{@base_url}/v1/proposals/#{proposal_id}"
 
-      response_body = %{"errors" => %{"detail" => "Service Unavailable"}}
-      mock(fn %{method: :put, url: ^proposal_url} -> json(response_body, status: 503) end)
+      mock(fn %{method: :put, url: ^proposal_url} -> {:error, :timeout} end)
 
-      assert {:error, expected_response} = Underwriter.update_proposal(client(), proposal)
-      assert %Tesla.Env{body: ^response_body, status: 503} = expected_response
+      assert Underwriter.update_proposal(client(), proposal) == {:error, :timeout}
     end
   end
 


### PR DESCRIPTION
**Why is this change necessary?**
- To support new proposal reopen flow. `Underwriter` needs to upsert proposal to publish the `underwriter.proposal.stage_changed` event.

**How does it address the issue?**
- Add `update_proposal` on `HttpClients.Underwriter`

**What side effects does this change have?**
- n/a

**Task card (link)**
- [ORG-1782](https://bcredi.atlassian.net/browse/ORG-1782)
