### PR TITLE
[SPRF-1097] fix SalesforceTokenServer function headers

### DIFF
--- a/lib/http_clients/salesforce_token_server.ex
+++ b/lib/http_clients/salesforce_token_server.ex
@@ -47,7 +47,7 @@ defmodule HttpClients.SalesforceTokenServer do
   use Agent
   require Logger
 
-  defguard is_token_server(server) when is_pid(server) or is_atom(server)
+  defguardp is_token_server(server) when is_pid(server) or is_atom(server)
 
   @spec start_link(keyword()) :: {:ok, pid()} | {:error, any()} | no_return()
   def start_link(opts) when is_list(opts) do

--- a/lib/http_clients/salesforce_token_server.ex
+++ b/lib/http_clients/salesforce_token_server.ex
@@ -80,7 +80,7 @@ defmodule HttpClients.SalesforceTokenServer do
   @doc "Request an authenticated token to Salesforce and set it to the given TokenServer"
   @spec update_token(pid()) :: :ok | no_return()
   def update_token(server) when is_token_server(server) do
-    Logger.info("Updating the salesforce token")
+    Logger.info("Updating Salesforce token for #{inspect(server)}")
     config = Agent.get(server, & &1[:config])
     {:ok, token} = request_new_token(config)
     set_token(server, token)
@@ -89,7 +89,7 @@ defmodule HttpClients.SalesforceTokenServer do
   @doc "Set a new token for the given TokenServer"
   @spec set_token(pid(), ExForce.OAuthResponse.t()) :: :ok
   def set_token(server, %ExForce.OAuthResponse{} = new_token) when is_token_server(server) do
-    Logger.info("Setting new token for #{inspect(server)}")
+    Logger.info("Setting new Salesforce token for #{inspect(server)}")
     Agent.update(server, &Map.put(&1, :token, new_token))
   end
 end

--- a/lib/http_clients/salesforce_token_server.ex
+++ b/lib/http_clients/salesforce_token_server.ex
@@ -47,7 +47,7 @@ defmodule HttpClients.SalesforceTokenServer do
   use Agent
   require Logger
 
-  defguard is_server(server) when is_pid(server) or is_atom(server)
+  defguard is_token_server(server) when is_pid(server) or is_atom(server)
 
   @spec start_link(keyword()) :: {:ok, pid()} | {:error, any()} | no_return()
   def start_link(opts) when is_list(opts) do
@@ -73,13 +73,13 @@ defmodule HttpClients.SalesforceTokenServer do
 
   @doc "Gets a token from the given TokenServer"
   @spec get_token(pid()) :: ExForce.OAuthResponse.t()
-  def get_token(server) when is_server(server) do
+  def get_token(server) when is_token_server(server) do
     Agent.get(server, & &1[:token])
   end
 
   @doc "Request an authenticated token to Salesforce and set it to the given TokenServer"
   @spec update_token(pid()) :: :ok | no_return()
-  def update_token(server) when is_server(server) do
+  def update_token(server) when is_token_server(server) do
     Logger.info("Updating the salesforce token")
     config = Agent.get(server, & &1[:config])
     {:ok, token} = request_new_token(config)
@@ -88,7 +88,7 @@ defmodule HttpClients.SalesforceTokenServer do
 
   @doc "Set a new token for the given TokenServer"
   @spec set_token(pid(), ExForce.OAuthResponse.t()) :: :ok
-  def set_token(server, %ExForce.OAuthResponse{} = new_token) when is_server(server) do
+  def set_token(server, %ExForce.OAuthResponse{} = new_token) when is_token_server(server) do
     Logger.info("Setting new token for #{inspect(server)}")
     Agent.update(server, &Map.put(&1, :token, new_token))
   end

--- a/lib/http_clients/salesforce_token_server.ex
+++ b/lib/http_clients/salesforce_token_server.ex
@@ -47,6 +47,8 @@ defmodule HttpClients.SalesforceTokenServer do
   use Agent
   require Logger
 
+  defguard is_server(server) when is_pid(server) or is_atom(server)
+
   @spec start_link(keyword()) :: {:ok, pid()} | {:error, any()} | no_return()
   def start_link(opts) when is_list(opts) do
     {config, opts} = Keyword.pop!(opts, :config)
@@ -71,13 +73,13 @@ defmodule HttpClients.SalesforceTokenServer do
 
   @doc "Gets a token from the given TokenServer"
   @spec get_token(pid()) :: ExForce.OAuthResponse.t()
-  def get_token(server) when is_pid(server) do
+  def get_token(server) when is_server(server) do
     Agent.get(server, & &1[:token])
   end
 
   @doc "Request an authenticated token to Salesforce and set it to the given TokenServer"
   @spec update_token(pid()) :: :ok | no_return()
-  def update_token(server) when is_pid(server) do
+  def update_token(server) when is_server(server) do
     Logger.info("Updating the salesforce token")
     config = Agent.get(server, & &1[:config])
     {:ok, token} = request_new_token(config)
@@ -86,7 +88,7 @@ defmodule HttpClients.SalesforceTokenServer do
 
   @doc "Set a new token for the given TokenServer"
   @spec set_token(pid(), ExForce.OAuthResponse.t()) :: :ok
-  def set_token(server, %ExForce.OAuthResponse{} = new_token) when is_pid(server) do
+  def set_token(server, %ExForce.OAuthResponse{} = new_token) when is_server(server) do
     Logger.info("Setting new token for #{inspect(server)}")
     Agent.update(server, &Map.put(&1, :token, new_token))
   end

--- a/lib/http_clients/salesforce_token_server.ex
+++ b/lib/http_clients/salesforce_token_server.ex
@@ -72,13 +72,13 @@ defmodule HttpClients.SalesforceTokenServer do
   end
 
   @doc "Gets a token from the given TokenServer"
-  @spec get_token(pid()) :: ExForce.OAuthResponse.t()
+  @spec get_token(atom() | pid()) :: ExForce.OAuthResponse.t()
   def get_token(server) when is_token_server(server) do
     Agent.get(server, & &1[:token])
   end
 
   @doc "Request an authenticated token to Salesforce and set it to the given TokenServer"
-  @spec update_token(pid()) :: :ok | no_return()
+  @spec update_token(atom() | pid()) :: :ok | no_return()
   def update_token(server) when is_token_server(server) do
     Logger.info("Updating Salesforce token for #{inspect(server)}")
     config = Agent.get(server, & &1[:config])
@@ -87,7 +87,7 @@ defmodule HttpClients.SalesforceTokenServer do
   end
 
   @doc "Set a new token for the given TokenServer"
-  @spec set_token(pid(), ExForce.OAuthResponse.t()) :: :ok
+  @spec set_token(atom() | pid(), ExForce.OAuthResponse.t()) :: :ok
   def set_token(server, %ExForce.OAuthResponse{} = new_token) when is_token_server(server) do
     Logger.info("Setting new Salesforce token for #{inspect(server)}")
     Agent.update(server, &Map.put(&1, :token, new_token))

--- a/test/http_clients/salesforce_token_server_test.exs
+++ b/test/http_clients/salesforce_token_server_test.exs
@@ -41,7 +41,8 @@ defmodule HttpClients.SalesforceTokenServerTest do
       json(@token_response)
     end)
 
-    {:ok, pid: start_supervised!({SalesforceTokenServer, config: @config})}
+    opts = [name: SalesforceTokenServer, config: @config]
+    {:ok, pid: start_supervised!({SalesforceTokenServer, opts})}
   end
 
   describe "start_link/1" do
@@ -75,6 +76,7 @@ defmodule HttpClients.SalesforceTokenServerTest do
   describe "get_token/1" do
     test "returns a token", %{pid: pid} do
       assert SalesforceTokenServer.get_token(pid) == @token
+      assert SalesforceTokenServer.get_token(SalesforceTokenServer) == @token
     end
   end
 
@@ -89,6 +91,7 @@ defmodule HttpClients.SalesforceTokenServerTest do
 
       :ok = SalesforceTokenServer.update_token(pid)
       assert SalesforceTokenServer.get_token(pid) == expected_token
+      assert SalesforceTokenServer.get_token(SalesforceTokenServer) == expected_token
     end
   end
 
@@ -111,6 +114,7 @@ defmodule HttpClients.SalesforceTokenServerTest do
       token = %ExForce.OAuthResponse{}
       :ok = SalesforceTokenServer.set_token(pid, token)
       assert SalesforceTokenServer.get_token(pid) == token
+      assert SalesforceTokenServer.get_token(SalesforceTokenServer) == token
     end
   end
 end


### PR DESCRIPTION
**Why is this change necessary?**

- To support using SalesforceTokenServer name instead of PID.

**How does it address the issue?**

- Changes `HttpClients.SalesforceTokenServer` function headers.

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-1097](https://bcredi.atlassian.net/browse/SPRF-1097)