### PR TITLE
[SPRF-1107] add bacen_source option to Neurotech.compute_bacen_score/5

### DIFF
--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -51,6 +51,7 @@ defmodule HttpClients.Neurotech do
         opts \\ []
       )
       when is_integer(transaction_id) and is_list(opts) do
+    bacen_source = Keyword.get(opts, :bacen_source)
     base_date = Keyword.get(opts, :base_date)
 
     inputs =
@@ -58,6 +59,7 @@ defmodule HttpClients.Neurotech do
         "PROP_POLITICA" => "BACEN_SCR",
         "PROP_BACEN_CPFCNPJ" => person.cpf
       }
+      |> put_bacen_source(bacen_source)
       |> put_base_date(base_date)
 
     request = %Request{
@@ -76,6 +78,13 @@ defmodule HttpClients.Neurotech do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp put_bacen_source(inputs, bacen_source)
+  defp put_bacen_source(inputs, nil), do: inputs
+
+  defp put_bacen_source(inputs, bacen_source) when is_binary(bacen_source) do
+    Map.put(inputs, "PROP_BACEN_FONTE", bacen_source)
   end
 
   defp put_base_date(inputs, base_date)

--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -80,19 +80,22 @@ defmodule HttpClients.Neurotech do
     end
   end
 
-  defp put_bacen_source(inputs, bacen_source)
-  defp put_bacen_source(inputs, nil), do: inputs
-
-  defp put_bacen_source(inputs, bacen_source) when is_binary(bacen_source) do
-    Map.put(inputs, "PROP_BACEN_FONTE", bacen_source)
+  defp put_bacen_source(inputs, bacen_source) do
+    cond do
+      is_nil(bacen_source) -> inputs
+      is_binary(bacen_source) -> Map.put(inputs, "PROP_BACEN_FONTE", bacen_source)
+    end
   end
 
-  defp put_base_date(inputs, base_date)
-  defp put_base_date(inputs, nil), do: inputs
+  defp put_base_date(inputs, base_date) do
+    cond do
+      is_nil(base_date) ->
+        inputs
 
-  defp put_base_date(inputs, %Date{} = base_date) do
-    base_date = Calendar.strftime(base_date, "%d/%m/%Y")
-    Map.put(inputs, "PROP_BACEN_DATA_BASE", base_date)
+      %Date{} = base_date ->
+        base_date = Calendar.strftime(base_date, "%d/%m/%Y")
+        Map.put(inputs, "PROP_BACEN_DATA_BASE", base_date)
+    end
   end
 
   defp parse_bacen_analysis(bacen_analysis) do

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -131,6 +131,33 @@ defmodule HttpClients.NeurotechTest do
                opts
              ) == {:ok, expected_analysis}
     end
+
+    test "computes score with bacen_source option" do
+      person = %Neurotech.Person{cpf: "65661563051"}
+      opts = [bacen_source: "SOME_BACEN_SOURCE"]
+
+      expected_analysis = %Score{
+        score: 444,
+        positive_analysis: "- Sem registro de vencidos no histórico.\r\n",
+        negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
+      }
+
+      response_body = bacen_response(:success)
+
+      mock(fn %{url: "/submit", method: :post, body: body} ->
+        assert String.match?(body, ~r/PROP_BACEN_FONTE/)
+        assert String.match?(body, ~r/SOME_BACEN_SOURCE/)
+        json(response_body)
+      end)
+
+      assert Neurotech.compute_bacen_score(
+               client(),
+               credentials(),
+               person,
+               @transaction_id,
+               opts
+             ) == {:ok, expected_analysis}
+    end
   end
 
   describe "client/1" do


### PR DESCRIPTION
**Why is this change necessary?**

- To support multiple originators on bacen_score policy request.
- The first commit is a refactor of the current tests (labels and order - fails first, then success cases), maybe start the review by them?

**How does it address the issue?**

- Add `bacen_source` option to `Neurotech.compute_bacen_score/5`;

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-1107](https://bcredi.atlassian.net/browse/SPRF-1107)
