### PR TITLE
[SPRF-1119] Creditas person structs and client

### DIFF
--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -1,0 +1,26 @@
+defmodule HttpClients.Creditas.PersonApi do
+  @spec client(String.t(), String.t()) :: Tesla.Client.t()
+  def client(base_url, bearer_token) do
+    headers = headers(bearer_token)
+
+    middlewares = [
+      {Tesla.Middleware.BaseUrl, base_url},
+      {Tesla.Middleware.Headers, headers},
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Retry, delay: 1_000, max_retries: 3},
+      {Tesla.Middleware.Timeout, timeout: 120_000},
+      Tesla.Middleware.Logger,
+      Goodies.Tesla.Middleware.RequestIdForwarder
+    ]
+
+    Tesla.client(middlewares)
+  end
+
+  defp headers(bearer_token) do
+    [
+      {"Authorization", "Bearer #{bearer_token}"},
+      {"X-Tenant-Id", "creditasbr"},
+      {"Accept", "application/vnd.creditas.v1+json"}
+    ]
+  end
+end

--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -1,4 +1,6 @@
 defmodule HttpClients.Creditas.PersonApi do
+  @moduledoc false
+
   @spec client(String.t(), String.t()) :: Tesla.Client.t()
   def client(base_url, bearer_token) do
     headers = headers(bearer_token)

--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -11,8 +11,7 @@ defmodule HttpClients.Creditas.PersonApi do
       Tesla.Middleware.JSON,
       {Tesla.Middleware.Retry, delay: 1_000, max_retries: 3},
       {Tesla.Middleware.Timeout, timeout: 120_000},
-      Tesla.Middleware.Logger,
-      Goodies.Tesla.Middleware.RequestIdForwarder
+      Tesla.Middleware.Logger
     ]
 
     Tesla.client(middlewares)

--- a/lib/http_clients/creditas/person_api/address.ex
+++ b/lib/http_clients/creditas/person_api/address.ex
@@ -1,0 +1,16 @@
+defmodule HttpClients.Creditas.PersonApi.Address do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          type: String.t(),
+          country: String.t(),
+          street: String.t(),
+          number: String.t(),
+          zipCode: String.t(),
+          neighborhood: String.t(),
+          complement: String.t()
+        }
+
+  @derive Jason.Encoder
+  defstruct ~w(type country street number zipCode neighborhood complement)a
+end

--- a/lib/http_clients/creditas/person_api/contact.ex
+++ b/lib/http_clients/creditas/person_api/contact.ex
@@ -1,0 +1,12 @@
+defmodule HttpClients.Creditas.PersonApi.Contact do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          channel: String.t(),
+          code: String.t(),
+          type: String.t()
+        }
+
+  @derive Jason.Encoder
+  defstruct ~w(channel code type)a
+end

--- a/lib/http_clients/creditas/person_api/main_document.ex
+++ b/lib/http_clients/creditas/person_api/main_document.ex
@@ -1,0 +1,11 @@
+defmodule HttpClients.Creditas.PersonApi.MainDocument do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          type: String.t(),
+          code: String.t()
+        }
+
+  @derive Jason.Encoder
+  defstruct ~w(type code)a
+end

--- a/lib/http_clients/creditas/person_api/person.ex
+++ b/lib/http_clients/creditas/person_api/person.ex
@@ -1,0 +1,17 @@
+defmodule HttpClients.Creditas.PersonApi.Person do
+  @moduledoc false
+
+  alias HttpClients.Creditas.PersonApi.{Address, Contact, MainDocument}
+
+  @type t :: %__MODULE__{
+          fullName: String.t(),
+          birthDate: Date.t(),
+          contacts: List.t(Contact.t()),
+          addresses: List.t(Address.t()),
+          mainDocument: MainDocument.t()
+        }
+
+  @enforce_keys ~w(fullName birthDate mainDocument)a
+  @derive Jason.Encoder
+  defstruct ~w(fullName birthDate contacts addresses mainDocument)a
+end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -1,0 +1,31 @@
+defmodule HttpClients.Creditas.PersonApiTest do
+  use ExUnit.Case
+
+  alias HttpClients.Creditas.PersonApi
+
+  describe "client/2" do
+    @base_url "https://api.creditas.io/persons"
+    @bearer_token "some_jwt_token"
+    @headers [
+      {"Authorization", "Bearer #{@bearer_token}"},
+      {"X-Tenant-Id", "creditasbr"},
+      {"Accept", "application/vnd.creditas.v1+json"}
+    ]
+
+    test "returns a tesla client" do
+      expected_configs = [
+        {Tesla.Middleware.BaseUrl, :call, [@base_url]},
+        {Tesla.Middleware.Headers, :call, [@headers]},
+        {Tesla.Middleware.JSON, :call, [[]]},
+        {Tesla.Middleware.Retry, :call, [[delay: 1000, max_retries: 3]]},
+        {Tesla.Middleware.Timeout, :call, [[timeout: 120_000]]},
+        {Tesla.Middleware.Logger, :call, [[]]},
+        {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
+      ]
+
+      client = PersonApi.client(@base_url, @bearer_token)
+      assert %Tesla.Client{} = client
+      assert client.pre == expected_configs
+    end
+  end
+end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -19,13 +19,11 @@ defmodule HttpClients.Creditas.PersonApiTest do
         {Tesla.Middleware.JSON, :call, [[]]},
         {Tesla.Middleware.Retry, :call, [[delay: 1000, max_retries: 3]]},
         {Tesla.Middleware.Timeout, :call, [[timeout: 120_000]]},
-        {Tesla.Middleware.Logger, :call, [[]]},
-        {Goodies.Tesla.Middleware.RequestIdForwarder, :call, [[]]}
+        {Tesla.Middleware.Logger, :call, [[]]}
       ]
 
       client = PersonApi.client(@base_url, @bearer_token)
-      assert %Tesla.Client{} = client
-      assert client.pre == expected_configs
+      assert %Tesla.Client{pre: ^expected_configs} = client
     end
   end
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -22,8 +22,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
         {Tesla.Middleware.Logger, :call, [[]]}
       ]
 
-      client = PersonApi.client(@base_url, @bearer_token)
-      assert %Tesla.Client{pre: ^expected_configs} = client
+      assert %Tesla.Client{pre: ^expected_configs} = PersonApi.client(@base_url, @bearer_token)
     end
   end
 end


### PR DESCRIPTION
**Why is this change necessary?**

- To make requests to the creditas person api

**How does it address the issue?**

- Creates the person api client
- Creates the person and related structures

**Task card (link)**

- [[http-clients] criar structs e Creditas.PersonAPI.client/2](https://bcredi.atlassian.net/browse/SPRF-1119)
