### PR TITLE
[SPRF-1120] Function to get person on creditas person client

### DIFF
--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -1,6 +1,35 @@
 defmodule HttpClients.Creditas.PersonApi do
   @moduledoc false
 
+  alias HttpClients.Creditas.PersonApi.{MainDocument, Person}
+
+  @spec get_person(Tesla.Client.t(), String.t()) :: Person.t()
+  def get_person(client, cpf) do
+    query = "mainDocument.code=#{cpf}"
+
+    case Tesla.get(client, "/persons", query: query) do
+      {:ok, %Tesla.Env{status: 200, body: attrs}} ->
+        {:ok, build_person(attrs)}
+
+        # {:ok, %Tesla.Env{} = response} ->
+        #   {:error, response}
+
+        # {:error, reason} ->
+        #   {:error, reason}
+    end
+  end
+
+  defp build_person(attrs) do
+    %Person{
+      fullName: attrs["fullName"],
+      birthDate: attrs["birthDate"],
+      mainDocument: %MainDocument{
+        type: attrs["mainDocument"]["type"],
+        code: attrs["mainDocument"]["code"]
+      }
+    }
+  end
+
   @spec client(String.t(), String.t()) :: Tesla.Client.t()
   def client(base_url, bearer_token) do
     headers = headers(bearer_token)

--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -23,42 +23,40 @@ defmodule HttpClients.Creditas.PersonApi do
     %Person{
       fullName: attrs["fullName"],
       birthDate: attrs["birthDate"],
-      contacts: build_contacts(attrs),
-      addresses: build_addresses(attrs),
-      mainDocument: %MainDocument{
-        type: attrs["mainDocument"]["type"],
-        code: attrs["mainDocument"]["code"]
-      }
+      contacts: build_contacts(attrs["contacts"]),
+      addresses: build_addresses(attrs["addresses"]),
+      mainDocument: build_main_document(attrs["mainDocument"])
     }
   end
 
-  defp build_contacts(attrs) do
-    Enum.reduce(attrs["contacts"], [], fn contact, contacts ->
-      [
-        %Contact{
-          channel: contact["channel"],
-          code: contact["code"],
-          type: contact["type"]
-        }
-        | contacts
-      ]
+  defp build_main_document(main_document) do
+    %MainDocument{
+      type: main_document["type"],
+      code: main_document["code"]
+    }
+  end
+
+  defp build_contacts(contacts) do
+    Enum.map(contacts, fn contact ->
+      %Contact{
+        channel: contact["channel"],
+        code: contact["code"],
+        type: contact["type"]
+      }
     end)
   end
 
-  defp build_addresses(attrs) do
-    Enum.reduce(attrs["addresses"], [], fn address, addresses ->
-      [
-        %Address{
-          type: address["type"],
-          country: address["country"],
-          street: address["street"],
-          number: address["number"],
-          zipCode: address["zipCode"],
-          neighborhood: address["neighborhood"],
-          complement: address["complement"]
-        }
-        | addresses
-      ]
+  defp build_addresses(addresses) do
+    Enum.map(addresses, fn address ->
+      %Address{
+        type: address["type"],
+        country: address["country"],
+        street: address["street"],
+        number: address["number"],
+        zipCode: address["zipCode"],
+        neighborhood: address["neighborhood"],
+        complement: address["complement"]
+      }
     end)
   end
 

--- a/lib/http_clients/creditas/person_api/address.ex
+++ b/lib/http_clients/creditas/person_api/address.ex
@@ -12,5 +12,6 @@ defmodule HttpClients.Creditas.PersonApi.Address do
         }
 
   @derive Jason.Encoder
+  @enforce_keys ~w(type country)a
   defstruct ~w(type country street number zipCode neighborhood complement)a
 end

--- a/lib/http_clients/creditas/person_api/contact.ex
+++ b/lib/http_clients/creditas/person_api/contact.ex
@@ -8,5 +8,6 @@ defmodule HttpClients.Creditas.PersonApi.Contact do
         }
 
   @derive Jason.Encoder
+  @enforce_keys ~w(channel code type)a
   defstruct ~w(channel code type)a
 end

--- a/lib/http_clients/creditas/person_api/person.ex
+++ b/lib/http_clients/creditas/person_api/person.ex
@@ -9,10 +9,10 @@ defmodule HttpClients.Creditas.PersonApi.Person do
           contacts: List.t(Contact.t()),
           addresses: List.t(Address.t()),
           mainDocument: MainDocument.t(),
-          version: integer()
+          currentVersion: integer()
         }
 
   @derive Jason.Encoder
   @enforce_keys ~w(fullName birthDate mainDocument)a
-  defstruct ~w(fullName birthDate contacts addresses mainDocument version)a
+  defstruct ~w(fullName birthDate contacts addresses mainDocument currentVersion)a
 end

--- a/lib/http_clients/creditas/person_api/person.ex
+++ b/lib/http_clients/creditas/person_api/person.ex
@@ -8,10 +8,11 @@ defmodule HttpClients.Creditas.PersonApi.Person do
           birthDate: Date.t(),
           contacts: List.t(Contact.t()),
           addresses: List.t(Address.t()),
-          mainDocument: MainDocument.t()
+          mainDocument: MainDocument.t(),
+          version: integer()
         }
 
-  @enforce_keys ~w(fullName birthDate mainDocument)a
   @derive Jason.Encoder
-  defstruct ~w(fullName birthDate contacts addresses mainDocument)a
+  @enforce_keys ~w(fullName birthDate mainDocument)a
+  defstruct ~w(fullName birthDate contacts addresses mainDocument version)a
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -81,16 +81,20 @@ defmodule HttpClients.Creditas.PersonApiTest do
         contacts: [
           %Contact{
             channel: "PHONE",
-            code: "55998788888",
+            code: "55998788454",
             type: "PERSONAL"
           },
           %Contact{
             channel: "PHONE",
-            code: "55998788454",
+            code: "55998788888",
             type: "PERSONAL"
           }
         ],
         addresses: [
+          %Address{
+            country: "BR",
+            type: "HOME"
+          },
           %Address{
             complement: "apto 123",
             country: "BR",
@@ -99,10 +103,6 @@ defmodule HttpClients.Creditas.PersonApiTest do
             street: "Av de bill",
             type: "BILLING",
             zipCode: "81810111"
-          },
-          %Address{
-            country: "BR",
-            type: "HOME"
           }
         ]
       }

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -84,19 +84,19 @@ defmodule HttpClients.Creditas.PersonApiTest do
         birthDate: "10-10-1990",
         mainDocument: %MainDocument{type: "CPF", code: @cpf},
         contacts: [
-          %HttpClients.Creditas.PersonApi.Contact{
+          %Contact{
             channel: "PHONE",
             code: "55998788888",
             type: "PERSONAL"
           },
-          %HttpClients.Creditas.PersonApi.Contact{
+          %Contact{
             channel: "PHONE",
             code: "55998788454",
             type: "PERSONAL"
           }
         ],
         addresses: [
-          %HttpClients.Creditas.PersonApi.Address{
+          %Address{
             complement: "some complement",
             country: "BR",
             neighborhood: "Centro",
@@ -105,7 +105,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
             type: "BILLING",
             zipCode: "81810111"
           },
-          %HttpClients.Creditas.PersonApi.Address{
+          %Address{
             complement: "some complement",
             country: "BR",
             neighborhood: "Xaxim",
@@ -120,7 +120,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
       assert {:ok, expected_response} == PersonApi.get_person_by_cpf(@client, @cpf)
     end
 
-    test "returns error when response is not successfull" do
+    test "returns error when request fails" do
       mock(fn %{url: "/persons", method: :get, query: @query} -> %Tesla.Env{status: 400} end)
       assert {:error, %Tesla.Env{status: 400}} == PersonApi.get_person_by_cpf(@client, @cpf)
     end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -34,7 +34,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
     @cpf "45658265002"
     @query "mainDocument.code=#{@cpf}"
     @response_body %{
-      "fullName" => "requested",
+      "fullName" => "Fulano Sicrano",
       "birthDate" => "10-10-1990",
       "mainDocument" => %{
         "type" => "CPF",
@@ -55,12 +55,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
       "addresses" => [
         %{
           "type" => "HOME",
-          "country" => "BR",
-          "street" => "Av de casa",
-          "number" => "1010",
-          "zipCode" => "81810110",
-          "neighborhood" => "Xaxim",
-          "complement" => "some complement"
+          "country" => "BR"
         },
         %{
           "type" => "BILLING",
@@ -69,7 +64,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
           "number" => "2020",
           "zipCode" => "81810111",
           "neighborhood" => "Centro",
-          "complement" => "some complement"
+          "complement" => "apto 123"
         }
       ]
     }
@@ -80,7 +75,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
       end)
 
       expected_response = %Person{
-        fullName: "requested",
+        fullName: "Fulano Sicrano",
         birthDate: "10-10-1990",
         mainDocument: %MainDocument{type: "CPF", code: @cpf},
         contacts: [
@@ -97,7 +92,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
         ],
         addresses: [
           %Address{
-            complement: "some complement",
+            complement: "apto 123",
             country: "BR",
             neighborhood: "Centro",
             number: "2020",
@@ -106,28 +101,23 @@ defmodule HttpClients.Creditas.PersonApiTest do
             zipCode: "81810111"
           },
           %Address{
-            complement: "some complement",
             country: "BR",
-            neighborhood: "Xaxim",
-            number: "1010",
-            street: "Av de casa",
-            type: "HOME",
-            zipCode: "81810110"
+            type: "HOME"
           }
         ]
       }
 
-      assert {:ok, expected_response} == PersonApi.get_person_by_cpf(@client, @cpf)
+      assert PersonApi.get_person_by_cpf(@client, @cpf) == {:ok, expected_response}
     end
 
     test "returns error when request fails" do
       mock(fn %{url: "/persons", method: :get, query: @query} -> %Tesla.Env{status: 400} end)
-      assert {:error, %Tesla.Env{status: 400}} == PersonApi.get_person_by_cpf(@client, @cpf)
+      assert PersonApi.get_person_by_cpf(@client, @cpf) == {:error, %Tesla.Env{status: 400}}
     end
 
     test "returns error when does not respond" do
       mock(fn %{url: "/persons", method: :get, query: @query} -> {:error, :timeout} end)
-      assert {:error, :timeout} == PersonApi.get_person_by_cpf(@client, @cpf)
+      assert PersonApi.get_person_by_cpf(@client, @cpf) == {:error, :timeout}
     end
   end
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -29,7 +29,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
     end
   end
 
-  describe "get_person_by_cpf/?" do
+  describe "get_person_by_cpf/2" do
     @client %Tesla.Client{}
     @cpf "45658265002"
     @query "mainDocument.code=#{@cpf}"

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -1,7 +1,10 @@
 defmodule HttpClients.Creditas.PersonApiTest do
   use ExUnit.Case
 
+  import Tesla.Mock
+
   alias HttpClients.Creditas.PersonApi
+  alias HttpClients.Creditas.PersonApi.{MainDocument, Person}
 
   describe "client/2" do
     @base_url "https://api.creditas.io/persons"
@@ -23,6 +26,36 @@ defmodule HttpClients.Creditas.PersonApiTest do
       ]
 
       assert %Tesla.Client{pre: ^expected_configs} = PersonApi.client(@base_url, @bearer_token)
+    end
+  end
+
+  describe "get_person/?" do
+    @cpf "45658265002"
+    @response_body %{
+      "fullName" => "requested",
+      "birthDate" => "10-10-1990",
+      "mainDocument" => %{
+        "type" => "CPF",
+        "code" => @cpf
+      }
+    }
+
+    test "returns person" do
+      query = "mainDocument.code=#{@cpf}"
+
+      mock(fn %{url: "/persons", method: :get, query: ^query} ->
+        %Tesla.Env{status: 200, body: @response_body}
+      end)
+
+      assert {:ok,
+              %Person{
+                fullName: "requested",
+                birthDate: "10-10-1990",
+                mainDocument: %MainDocument{
+                  type: "CPF",
+                  code: @cpf
+                }
+              }} == PersonApi.get_person(%Tesla.Client{}, @cpf)
     end
   end
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -54,12 +54,21 @@ defmodule HttpClients.Creditas.PersonApiTest do
       ],
       "addresses" => [
         %{
-          "type" => "BILLING",
+          "type" => "HOME",
           "country" => "BR",
           "street" => "Av de casa",
           "number" => "1010",
           "zipCode" => "81810110",
           "neighborhood" => "Xaxim",
+          "complement" => "some complement"
+        },
+        %{
+          "type" => "BILLING",
+          "country" => "BR",
+          "street" => "Av de bill",
+          "number" => "2020",
+          "zipCode" => "81810111",
+          "neighborhood" => "Centro",
           "complement" => "some complement"
         }
       ]
@@ -87,29 +96,38 @@ defmodule HttpClients.Creditas.PersonApiTest do
           }
         ],
         addresses: [
-          %Address{
-            type: "BILLING",
+          %HttpClients.Creditas.PersonApi.Address{
+            complement: "some complement",
             country: "BR",
-            street: "Av de casa",
-            number: "1010",
-            zipCode: "81810110",
+            neighborhood: "Centro",
+            number: "2020",
+            street: "Av de bill",
+            type: "BILLING",
+            zipCode: "81810111"
+          },
+          %HttpClients.Creditas.PersonApi.Address{
+            complement: "some complement",
+            country: "BR",
             neighborhood: "Xaxim",
-            complement: "some complement"
+            number: "1010",
+            street: "Av de casa",
+            type: "HOME",
+            zipCode: "81810110"
           }
         ]
       }
 
-      assert {:ok, expected_response} == PersonApi.get_person(@client, @cpf)
+      assert {:ok, expected_response} == PersonApi.get_person_by_cpf(@client, @cpf)
     end
 
     test "returns error when response is not successfull" do
       mock(fn %{url: "/persons", method: :get, query: @query} -> %Tesla.Env{status: 400} end)
-      assert {:error, %Tesla.Env{status: 400}} == PersonApi.get_person(@client, @cpf)
+      assert {:error, %Tesla.Env{status: 400}} == PersonApi.get_person_by_cpf(@client, @cpf)
     end
 
     test "returns error when does not respond" do
       mock(fn %{url: "/persons", method: :get, query: @query} -> {:error, :timeout} end)
-      assert {:error, :timeout} == PersonApi.get_person(@client, @cpf)
+      assert {:error, :timeout} == PersonApi.get_person_by_cpf(@client, @cpf)
     end
   end
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -74,7 +74,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
         %Tesla.Env{status: 200, body: @response_body}
       end)
 
-      expected_response = %Person{
+      expected_person = %Person{
         fullName: "Fulano Sicrano",
         birthDate: "10-10-1990",
         mainDocument: %MainDocument{type: "CPF", code: @cpf},
@@ -107,7 +107,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
         ]
       }
 
-      assert PersonApi.get_person_by_cpf(@client, @cpf) == {:ok, expected_response}
+      assert PersonApi.get_person_by_cpf(@client, @cpf) == {:ok, expected_person}
     end
 
     test "returns error when request fails" do


### PR DESCRIPTION
**Why is this change necessary?**

- To use the function to request persons on creditas-acl

**How does it address the issue?**

- Implements the function and tests for the `GET person` on creditas person api

**Task card (link)**

- [[http-clients] rota PersonAPI - GET person](https://bcredi.atlassian.net/browse/SPRF-1120)
