### PR TITLE
[SPRF-1121] Create a person on Creditas API

### DIFF
--- a/lib/http_clients/creditas/person_api/person.ex
+++ b/lib/http_clients/creditas/person_api/person.ex
@@ -4,15 +4,17 @@ defmodule HttpClients.Creditas.PersonApi.Person do
   alias HttpClients.Creditas.PersonApi.{Address, Contact, MainDocument}
 
   @type t :: %__MODULE__{
+          id: binary(),
           fullName: String.t(),
           birthDate: Date.t(),
           contacts: List.t(Contact.t()),
           addresses: List.t(Address.t()),
           mainDocument: MainDocument.t(),
+          version: integer(),
           currentVersion: integer()
         }
 
   @derive Jason.Encoder
   @enforce_keys ~w(fullName birthDate mainDocument)a
-  defstruct ~w(fullName birthDate contacts addresses mainDocument currentVersion)a
+  defstruct ~w(id fullName birthDate contacts addresses mainDocument version currentVersion)a
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -147,7 +147,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
       assert PersonApi.get_person_by_cpf(@client, @cpf) == {:error, %Tesla.Env{status: 400}}
     end
 
-    test "returns error when does not respond" do
+    test "returns error when couldn't call Creditas API" do
       mock(fn %{url: "/persons", method: :get, query: @query} -> {:error, :timeout} end)
       assert PersonApi.get_person_by_cpf(@client, @cpf) == {:error, :timeout}
     end
@@ -171,7 +171,7 @@ defmodule HttpClients.Creditas.PersonApiTest do
                {:error, %Tesla.Env{status: 400}}
     end
 
-    test "returns error when does not respond" do
+    test "returns error when couldn't call Creditas API" do
       mock(fn %{url: "/persons", method: :post} -> {:error, :timeout} end)
       assert PersonApi.create_person(@client, @create_person_request) == {:error, :timeout}
     end


### PR DESCRIPTION
**Why is this change necessary?**

- To use the function to create persons on creditas-acl

**How does it address the issue?**

- Implements the function and tests for the POST person on creditas person API

**What side effects does this change have?**
- n/a

**Task card (link)**
- [SPRF-1121](https://bcredi.atlassian.net/browse/SPRF-1121)
