### PR TITLE
[SPRF-1124] accept person as a map for creation

### DIFF
--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -15,9 +15,9 @@ defmodule HttpClients.Creditas.PersonApi do
   end
 
   @spec create_person(Tesla.Client.t(), map()) :: {:error, any} | {:ok, Person.t()}
-  def create_person(client, person_attrs) do
-    case Tesla.post(client, "/persons", person_attrs) do
-      {:ok, %Tesla.Env{status: 201, body: response_attrs}} -> {:ok, build_person(response_attrs)}
+  def create_person(client, attrs) do
+    case Tesla.post(client, "/persons", attrs) do
+      {:ok, %Tesla.Env{status: 201, body: response_body}} -> {:ok, build_person(response_body)}
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -14,12 +14,10 @@ defmodule HttpClients.Creditas.PersonApi do
     end
   end
 
-  @spec create_person(Tesla.Client.t(), Person.t()) :: {:error, any} | {:ok, Person.t()}
-  def create_person(client, %Person{} = person) do
-    person = Map.from_struct(person)
-
-    case Tesla.post(client, "/persons", person) do
-      {:ok, %Tesla.Env{status: 201, body: attrs}} -> {:ok, build_person(attrs)}
+  @spec create_person(Tesla.Client.t(), map()) :: {:error, any} | {:ok, Person.t()}
+  def create_person(client, person_attrs) do
+    case Tesla.post(client, "/persons", person_attrs) do
+      {:ok, %Tesla.Env{status: 201, body: response_attrs}} -> {:ok, build_person(response_attrs)}
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -164,26 +164,32 @@ defmodule HttpClients.Creditas.PersonApiTest do
   end
 
   describe "create_person/2" do
-    @create_person_request Map.drop(@person, [:id, :version])
+    @create_person_attrs %{
+      "fullName" => "Joãozinho Junior",
+      "mainDocument" => %{
+        "type" => "CPF",
+        "code" => "344.189.910-50"
+      }
+    }
 
     test "returns a person" do
       mock_global(fn %{url: "#{@base_url}/persons", method: :post} ->
         %Tesla.Env{status: 201, body: @response_body}
       end)
 
-      assert PersonApi.create_person(@client, @create_person_request) == {:ok, @person}
+      assert PersonApi.create_person(@client, @create_person_attrs) == {:ok, @person}
     end
 
     test "returns error when request fails" do
       mock_global(fn %{url: "#{@base_url}/persons", method: :post} -> %Tesla.Env{status: 400} end)
 
-      assert PersonApi.create_person(@client, @create_person_request) ==
+      assert PersonApi.create_person(@client, @create_person_attrs) ==
                {:error, %Tesla.Env{status: 400}}
     end
 
     test "returns error when couldn't call Creditas API" do
       mock_global(fn %{url: "#{@base_url}/persons", method: :post} -> {:error, :timeout} end)
-      assert PersonApi.create_person(@client, @create_person_request) == {:error, :timeout}
+      assert PersonApi.create_person(@client, @create_person_attrs) == {:error, :timeout}
     end
   end
 


### PR DESCRIPTION
Please enter the commit message for your changes. Lines starting

**Why is this change necessary?**

- Using the person struct on the creation request sends some keys not accepted by the creation API.

**How does it address the issue?**

- Accepts attrs as a map to create person

**Task card (link)**

- [SPRF-1124](https://bcredi.atlassian.net/browse/SPRF-1124)
