### PR TITLE
[SPRF0-1019] - Fix string to integer when return is empty

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
       - name: Run tests
-        run: MIX_ENV=test mix coveralls
+        run: mix coveralls
       - name: Run credo
         run: mix credo --strict
       - name: Run format

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
       - name: Run tests
-        run: mix coveralls
+        run: MIX_ENV=test mix coveralls
       - name: Run credo
         run: mix credo --strict
       - name: Run format

--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -100,9 +100,9 @@ defmodule HttpClients.Neurotech do
 
   defp parse_bacen_analysis(bacen_analysis) do
     %Score{
-      score: get_value(bacen_analysis, "CALC_BCREDISCORE_SCORE") |> String.to_integer(),
+      score: get_score(bacen_analysis),
       positive_analysis: get_value(bacen_analysis, "CALC_BACEN_PONTOS_POSITIVOS"),
-      negative_analysis: bacen_analysis |> get_value("CALC_BACEN_PONTOS_NEGATIVOS")
+      negative_analysis: get_value(bacen_analysis, "CALC_BACEN_PONTOS_NEGATIVOS")
     }
   end
 
@@ -114,6 +114,14 @@ defmodule HttpClients.Neurotech do
       "" -> nil
       value -> value
     end
+  end
+
+  defp get_score(bacen_analysis) do
+    score = get_value(bacen_analysis, "CALC_BCREDISCORE_SCORE")
+
+    if is_binary(score),
+      do: String.to_integer(score),
+      else: 0
   end
 
   @spec client(String.t()) :: Tesla.Client.t()

--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -42,7 +42,7 @@ defmodule HttpClients.Neurotech do
   defp approved?(status), do: status == "APROVADO"
 
   @spec compute_bacen_score(Tesla.Client.t(), Credentials.t(), Person.t(), integer(), Keyword.t()) ::
-          {:ok, map()} | {:error, any()}
+          {:ok, Score.t()} | {:error, any()}
   def compute_bacen_score(
         %Tesla.Client{} = client,
         %Credentials{} = credentials,

--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -121,7 +121,7 @@ defmodule HttpClients.Neurotech do
 
     if is_binary(score),
       do: String.to_integer(score),
-      else: 0
+      else: nil
   end
 
   @spec client(String.t()) :: Tesla.Client.t()

--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -106,6 +106,12 @@ defmodule HttpClients.Neurotech do
     }
   end
 
+  defp get_score(bacen_analysis) do
+    score = get_value(bacen_analysis, "CALC_BCREDISCORE_SCORE")
+
+    if is_binary(score), do: String.to_integer(score), else: nil
+  end
+
   defp get_value(bacen_analysis, key) do
     bacen_analysis["Result"]["Outputs"]
     |> Enum.find(%{}, &(&1["Key"] == key))
@@ -114,14 +120,6 @@ defmodule HttpClients.Neurotech do
       "" -> nil
       value -> value
     end
-  end
-
-  defp get_score(bacen_analysis) do
-    score = get_value(bacen_analysis, "CALC_BCREDISCORE_SCORE")
-
-    if is_binary(score),
-      do: String.to_integer(score),
-      else: nil
   end
 
   @spec client(String.t()) :: Tesla.Client.t()

--- a/test/http_clients/fixtures/neurotech.ex
+++ b/test/http_clients/fixtures/neurotech.ex
@@ -75,7 +75,7 @@ defmodule HttpClients.Fixtures.Neurotech do
     }
   end
 
-  def bacen_response(:empty_calc_score) do
+  def bacen_response(:empty_score) do
     %{
       "StatusCode" => "0100",
       "Result" => %{

--- a/test/http_clients/fixtures/neurotech.ex
+++ b/test/http_clients/fixtures/neurotech.ex
@@ -53,7 +53,7 @@ defmodule HttpClients.Fixtures.Neurotech do
     }
   end
 
-  def bacen_response(:empty_positive_analysis) do
+  def bacen_response(:empty_negative_analysis) do
     %{
       "StatusCode" => "0100",
       "Result" => %{
@@ -69,6 +69,28 @@ defmodule HttpClients.Fixtures.Neurotech do
           %{
             "Key" => "CALC_BCREDISCORE_SCORE",
             "Value" => "444"
+          }
+        ]
+      }
+    }
+  end
+
+  def bacen_response(:empty_calc_score) do
+    %{
+      "StatusCode" => "0100",
+      "Result" => %{
+        "Outputs" => [
+          %{
+            "Key" => "CALC_BACEN_PONTOS_NEGATIVOS",
+            "Value" => "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
+          },
+          %{
+            "Key" => "CALC_BACEN_PONTOS_POSITIVOS",
+            "Value" => "- Sem registro de vencidos no histórico.\r\n"
+          },
+          %{
+            "Key" => "CALC_BCREDISCORE_SCORE",
+            "Value" => ""
           }
         ]
       }

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -80,7 +80,7 @@ defmodule HttpClients.NeurotechTest do
         negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
       }
 
-      response_body = bacen_response(:empty_calc_score)
+      response_body = bacen_response(:empty_score)
       mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
 
       assert Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id) ==

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -103,7 +103,7 @@ defmodule HttpClients.NeurotechTest do
 
     test "computes score with neurotech calc score empty" do
       expected_analysis = %Score{
-        score: 0,
+        score: nil,
         positive_analysis: "- Sem registro de vencidos no histórico.\r\n",
         negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
       }

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -73,6 +73,20 @@ defmodule HttpClients.NeurotechTest do
                Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id)
     end
 
+    test "returns empty score when neurotech calculated score isn't a integer" do
+      expected_analysis = %Score{
+        score: nil,
+        positive_analysis: "- Sem registro de vencidos no histórico.\r\n",
+        negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
+      }
+
+      response_body = bacen_response(:empty_calc_score)
+      mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
+
+      assert Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id) ==
+               {:ok, expected_analysis}
+    end
+
     test "computes score" do
       expected_analysis = %Score{
         score: 444,
@@ -95,20 +109,6 @@ defmodule HttpClients.NeurotechTest do
       }
 
       response_body = bacen_response(:empty_negative_analysis)
-      mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
-
-      assert Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id) ==
-               {:ok, expected_analysis}
-    end
-
-    test "computes score when neurotech calculated score returns empty" do
-      expected_analysis = %Score{
-        score: nil,
-        positive_analysis: "- Sem registro de vencidos no histórico.\r\n",
-        negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
-      }
-
-      response_body = bacen_response(:empty_calc_score)
       mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
 
       assert Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id) ==

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -73,7 +73,7 @@ defmodule HttpClients.NeurotechTest do
                Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id)
     end
 
-    test "returns empty score when neurotech calculated score isn't a integer" do
+    test "returns empty score when the calculated score is invalid" do
       expected_analysis = %Score{
         score: nil,
         positive_analysis: "- Sem registro de vencidos no histórico.\r\n",

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -101,7 +101,7 @@ defmodule HttpClients.NeurotechTest do
                {:ok, expected_analysis}
     end
 
-    test "computes score with neurotech calc score empty" do
+    test "computes score when neurotech calculated score returns empty" do
       expected_analysis = %Score{
         score: nil,
         positive_analysis: "- Sem registro de vencidos no histórico.\r\n",

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -94,7 +94,21 @@ defmodule HttpClients.NeurotechTest do
         negative_analysis: nil
       }
 
-      response_body = bacen_response(:empty_positive_analysis)
+      response_body = bacen_response(:empty_negative_analysis)
+      mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
+
+      assert Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id) ==
+               {:ok, expected_analysis}
+    end
+
+    test "computes score with neurotech calc score empty" do
+      expected_analysis = %Score{
+        score: 0,
+        positive_analysis: "- Sem registro de vencidos no histórico.\r\n",
+        negative_analysis: "- LIMITE DE CRÉDITO abaixo de R$1.000,00 no histórico.\r\n"
+      }
+
+      response_body = bacen_response(:empty_calc_score)
       mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
 
       assert Neurotech.compute_bacen_score(client(), credentials(), @person, @transaction_id) ==


### PR DESCRIPTION
**Why is this change necessary?**

- We can't try parse a nil to integer, so we have to check it before.

**How does it address the issue?**

- If neurotech return isn't a binary (string), then returns 0;

**What side effects does this change have?**

- `mix deps.update http_client` mainly in `bacen-scoring` service

**Task card (link)**

- [Tratar retorno nulo neurotech](https://bcredi.atlassian.net/browse/SPRF-1019)
