### PR TITLE
[SPRF-1168] Adds state and city to person

### DIFF
--- a/lib/http_clients/creditas/person_api.ex
+++ b/lib/http_clients/creditas/person_api.ex
@@ -74,7 +74,9 @@ defmodule HttpClients.Creditas.PersonApi do
         number: address["number"],
         zipCode: address["zipCode"],
         neighborhood: address["neighborhood"],
-        complement: address["complement"]
+        complement: address["complement"],
+        administrativeAreaLevel1: address["administrativeAreaLevel1"],
+        administrativeAreaLevel2: address["administrativeAreaLevel2"]
       }
     end)
   end

--- a/lib/http_clients/creditas/person_api/address.ex
+++ b/lib/http_clients/creditas/person_api/address.ex
@@ -8,10 +8,12 @@ defmodule HttpClients.Creditas.PersonApi.Address do
           number: String.t(),
           zipCode: String.t(),
           neighborhood: String.t(),
-          complement: String.t()
+          complement: String.t(),
+          administrativeAreaLevel1: String.t(),
+          administrativeAreaLevel2: String.t()
         }
 
   @derive Jason.Encoder
   @enforce_keys ~w(type country)a
-  defstruct ~w(type country street number zipCode neighborhood complement)a
+  defstruct ~w(type country street number zipCode neighborhood complement administrativeAreaLevel1 administrativeAreaLevel2)a
 end

--- a/lib/http_clients/creditas/person_api/address.ex
+++ b/lib/http_clients/creditas/person_api/address.ex
@@ -15,5 +15,6 @@ defmodule HttpClients.Creditas.PersonApi.Address do
 
   @derive Jason.Encoder
   @enforce_keys ~w(type country)a
-  defstruct ~w(type country street number zipCode neighborhood complement administrativeAreaLevel1 administrativeAreaLevel2)a
+  defstruct ~w(type country street number zipCode neighborhood complement administrativeAreaLevel1
+  administrativeAreaLevel2)a
 end

--- a/test/http_clients/creditas/person_api_test.exs
+++ b/test/http_clients/creditas/person_api_test.exs
@@ -45,7 +45,9 @@ defmodule HttpClients.Creditas.PersonApiTest do
         "number" => "2020",
         "zipCode" => "81810111",
         "neighborhood" => "Centro",
-        "complement" => "apto 123"
+        "complement" => "apto 123",
+        "administrativeAreaLevel1" => "PR",
+        "administrativeAreaLevel2" => "Curitiba"
       }
     ]
   }
@@ -83,7 +85,9 @@ defmodule HttpClients.Creditas.PersonApiTest do
         number: "2020",
         street: "Av de bill",
         type: "BILLING",
-        zipCode: "81810111"
+        zipCode: "81810111",
+        administrativeAreaLevel1: "PR",
+        administrativeAreaLevel2: "Curitiba"
       }
     ]
   }


### PR DESCRIPTION
**Why is this change necessary?**

- When creating an loan, we need the person to have administrative area level fields filled with city and state

**How does it address the issue?**

- Accepts administrativeAreaLevel 1 and 2 for state and city

**Task card (link)**

- [[http-clients e crm-acl] Adicionar cidade e estado no endereço da pessoa](https://bcredi.atlassian.net/browse/SPRG-1168)
