### PR TITLE
[SPRF-1243] add Underwriter.get_main_proponent/2

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -13,6 +13,15 @@ defmodule HttpClients.Underwriter do
     end
   end
 
+  @spec get_main_proponent(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
+  def get_main_proponent(%Tesla.Client{} = client, proponent_id) do
+    case Tesla.get(client, "/v1/main-proponents/#{proponent_id}") do
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Proponent.t()}
   def create_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.post(client, "/v1/proponents", proponent) do


### PR DESCRIPTION
**Why is this change necessary?**

- To support the new route.

**How does it address the issue?**

- Add `Underwriter.get_main_proponent/2`;

**What side effects does this change have?**

- N/A

**Task card (link)**

- [SPRF-1243](https://bcredi.atlassian.net/browse/SPRF-1243)
