### PR TITLE
[SPRF-1249] Function to get underwriter proposal

### DIFF
--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -22,6 +22,20 @@ defmodule HttpClients.Underwriter do
     end
   end
 
+  @spec get_proposal(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
+  def get_proposal(%Tesla.Client{} = client, proposal_id) do
+    case Tesla.get(client, "/v1/proposals/#{proposal_id}") do
+      {:ok, %Tesla.Env{status: 200} = response} ->
+        {:ok, response}
+
+      {:ok, %Tesla.Env{} = response} ->
+        {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @spec create_proponent(Tesla.Client.t(), Proponent.t()) :: {:error, any} | {:ok, Proponent.t()}
   def create_proponent(%Tesla.Client{} = client, %Proponent{} = proponent) do
     case Tesla.post(client, "/v1/proponents", proponent) do

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -25,14 +25,9 @@ defmodule HttpClients.Underwriter do
   @spec get_proposal(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
   def get_proposal(%Tesla.Client{} = client, proposal_id) do
     case Tesla.get(client, "/v1/proposals/#{proposal_id}") do
-      {:ok, %Tesla.Env{status: 200} = response} ->
-        {:ok, response}
-
-      {:ok, %Tesla.Env{} = response} ->
-        {:error, response}
-
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+      {:ok, %Tesla.Env{} = response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/http_clients/underwriter.ex
+++ b/lib/http_clients/underwriter.ex
@@ -25,7 +25,7 @@ defmodule HttpClients.Underwriter do
   @spec get_proposal(Tesla.Client.t(), String.t()) :: {:error, any} | {:ok, Tesla.Env.t()}
   def get_proposal(%Tesla.Client{} = client, proposal_id) do
     case Tesla.get(client, "/v1/proposals/#{proposal_id}") do
-      {:ok, %Tesla.Env{status: 200} = response} -> {:ok, response}
+      {:ok, %Tesla.Env{status: 200, body: body}} -> {:ok, build_proposal(body["data"])}
       {:ok, %Tesla.Env{} = response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -130,17 +130,16 @@ defmodule HttpClients.UnderwriterTest do
 
     test "returns a proposal" do
       proposal_id = UUID.uuid4()
+      sales_stage = "open"
       proposals_url = "#{@base_url}/v1/proposals/#{proposal_id}"
 
       mock(fn %{method: :get, url: ^proposals_url} ->
-        json(%{"id" => proposal_id})
+        proposal = %{"id" => proposal_id, "sales_stage" => sales_stage}
+        json(%{"data" => proposal}, status: 200)
       end)
 
-      assert {:ok, %Tesla.Env{body: response_body, status: 200}} =
+      assert {:ok, %Proposal{id: ^proposal_id, sales_stage: ^sales_stage}} =
                Underwriter.get_proposal(client(), proposal_id)
-
-      expected_response_body = %{"id" => proposal_id}
-      assert response_body == expected_response_body
     end
   end
 

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -101,7 +101,7 @@ defmodule HttpClients.UnderwriterTest do
       proponent_id = UUID.uuid4()
       proponents_url = "#{@base_url}/v1/proponents/#{proponent_id}"
       mock(fn %{method: :get, url: ^proponents_url} -> {:error, :timeout} end)
-      assert {:error, :timeout} = Underwriter.get_proponent(client(), proponent_id)
+      assert Underwriter.get_proponent(client(), proponent_id) == {:error, :timeout}
     end
   end
 

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -121,10 +121,8 @@ defmodule HttpClients.UnderwriterTest do
         %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not Found"}}}
       end)
 
-      assert {:error, %Tesla.Env{body: response_body, status: 404}} =
+      assert {:error, %Tesla.Env{body: %{"errors" => %{"detail" => "Not Found"}}, status: 404}} =
                Underwriter.get_proposal(client(), proposal_id)
-
-      assert response_body == %{"errors" => %{"detail" => "Not Found"}}
     end
 
     test "returns a proposal" do

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -124,8 +124,7 @@ defmodule HttpClients.UnderwriterTest do
       assert {:error, %Tesla.Env{body: response_body, status: 404}} =
                Underwriter.get_proposal(client(), proposal_id)
 
-      expected_response_body = %{"errors" => %{"detail" => "Not Found"}}
-      assert response_body == expected_response_body
+      assert response_body == %{"errors" => %{"detail" => "Not Found"}}
     end
 
     test "returns a proposal" do

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -121,8 +121,10 @@ defmodule HttpClients.UnderwriterTest do
         %Tesla.Env{status: 404, body: %{"errors" => %{"detail" => "Not Found"}}}
       end)
 
-      assert {:error, %Tesla.Env{body: %{"errors" => %{"detail" => "Not Found"}}, status: 404}} =
+      assert {:error, %Tesla.Env{body: response_body, status: 404}} =
                Underwriter.get_proposal(client(), proposal_id)
+
+      assert response_body == %{"errors" => %{"detail" => "Not Found"}}
     end
 
     test "returns a proposal" do


### PR DESCRIPTION
**Why is this change necessary?**

- We need to get proposals on underwriter to adapt the qualification flow

**How does it address the issue?**

- Adds function to get proposals on underwriter

**Task card (link)**

- [SPRF-1249](https://bcredi.atlassian.net/browse/SPRF-1249)
