### PR TITLE
[SPRF-1249] adds fields to underwriter proposal

### DIFF
--- a/lib/http_clients/underwriter/credit_analysis.ex
+++ b/lib/http_clients/underwriter/credit_analysis.ex
@@ -1,0 +1,13 @@
+defmodule HttpClients.Underwriter.CreditAnalysis do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          warranty_value_status: String.t(),
+          warranty_region_status: String.t(),
+          warranty_type_status: String.t(),
+          pre_qualified: boolean()
+        }
+
+  @derive Jason.Encoder
+  defstruct ~w(warranty_value_status warranty_region_status warranty_type_status pre_qualified)a
+end

--- a/lib/http_clients/underwriter/partner.ex
+++ b/lib/http_clients/underwriter/partner.ex
@@ -1,0 +1,7 @@
+defmodule HttpClients.Underwriter.Partner do
+  @moduledoc false
+
+  @type t :: %__MODULE__{partner_type: String.t(), slug: String.t()}
+  @derive Jason.Encoder
+  defstruct ~w(partner_type slug)a
+end

--- a/lib/http_clients/underwriter/proponent.ex
+++ b/lib/http_clients/underwriter/proponent.ex
@@ -16,5 +16,6 @@ defmodule HttpClients.Underwriter.Proponent do
         }
 
   @derive Jason.Encoder
-  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent serial_id bacen_score id_validation_status)a
+  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent serial_id bacen_score
+    id_validation_status)a
 end

--- a/lib/http_clients/underwriter/proponent.ex
+++ b/lib/http_clients/underwriter/proponent.ex
@@ -7,11 +7,14 @@ defmodule HttpClients.Underwriter.Proponent do
           email: String.t(),
           cpf: String.t(),
           name: String.t(),
+          mobile_phone_number: String.t(),
           proposal_id: binary(),
           added_by_proponent: String.t(),
-          serial_id: integer()
+          serial_id: integer(),
+          id_validation_status: String.t(),
+          bacen_score: integer()
         }
 
   @derive Jason.Encoder
-  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent serial_id)a
+  defstruct ~w(id birthdate email cpf name mobile_phone_number proposal_id added_by_proponent serial_id bacen_score id_validation_status)a
 end

--- a/lib/http_clients/underwriter/proposal.ex
+++ b/lib/http_clients/underwriter/proposal.ex
@@ -16,5 +16,6 @@ defmodule HttpClients.Underwriter.Proposal do
         }
 
   @derive Jason.Encoder
-  defstruct ~w(id sales_stage lost_reason status blearning_lead_score main_proponent partner credit_analysis proposal_simulation)a
+  defstruct ~w(id sales_stage lost_reason status blearning_lead_score main_proponent partner credit_analysis
+    proposal_simulation)a
 end

--- a/lib/http_clients/underwriter/proposal.ex
+++ b/lib/http_clients/underwriter/proposal.ex
@@ -1,12 +1,20 @@
 defmodule HttpClients.Underwriter.Proposal do
   @moduledoc false
 
+  alias HttpClients.Underwriter.{CreditAnalysis, Partner, Proponent, ProposalSimulation}
+
   @type t :: %__MODULE__{
           id: binary(),
           sales_stage: String.t(),
-          lost_reason: String.t()
+          lost_reason: String.t(),
+          status: String.t(),
+          blearning_lead_score: integer(),
+          main_proponent: Proponent.t(),
+          partner: Partner.t(),
+          credit_analysis: CreditAnalysis.t(),
+          proposal_simulation: ProposalSimulation.t()
         }
 
   @derive Jason.Encoder
-  defstruct ~w(id sales_stage lost_reason)a
+  defstruct ~w(id sales_stage lost_reason status blearning_lead_score main_proponent partner credit_analysis proposal_simulation)a
 end

--- a/lib/http_clients/underwriter/proposal_simulation.ex
+++ b/lib/http_clients/underwriter/proposal_simulation.ex
@@ -1,0 +1,8 @@
+defmodule HttpClients.Underwriter.ProposalSimulation do
+  @moduledoc false
+
+  @type t :: %__MODULE__{loan_requested_amount: Decimal.t(), financing_type: String.t()}
+
+  @derive Jason.Encoder
+  defstruct ~w(loan_requested_amount financing_type)a
+end

--- a/test/http_clients/underwriter_test.exs
+++ b/test/http_clients/underwriter_test.exs
@@ -3,7 +3,7 @@ defmodule HttpClients.UnderwriterTest do
   import Tesla.Mock
 
   alias HttpClients.Underwriter
-  alias HttpClients.Underwriter.{Proponent, Proposal}
+  alias HttpClients.Underwriter.{CreditAnalysis, Partner, Proponent, Proposal, ProposalSimulation}
 
   @base_url "http://bcredi.com"
   @client_id "client-id"
@@ -106,6 +106,69 @@ defmodule HttpClients.UnderwriterTest do
   end
 
   describe "get_proposal/2" do
+    @proposal_id UUID.uuid4()
+    @get_proposal_response %{
+      "data" => %{
+        "id" => @proposal_id,
+        "status" => "open",
+        "blearning_lead_score" => 987,
+        "main_proponent" => %{
+          "id_validation_status" => "some id_validation_status",
+          "bacen_score" => 515,
+          "name" => "some name",
+          "email" => "some@email.com",
+          "mobile_phone_number" => "some mobile_phone_number",
+          "birthdate" => ~D[1990-12-31],
+          "cpf" => "84931981100"
+        },
+        "partner" => %{
+          "partner_type" => "some partner_type",
+          "slug" => "some slug"
+        },
+        "credit_analysis" => %{
+          "warranty_region_status" => "approved",
+          "warranty_type_status" => "approved",
+          "warranty_value_status" => "approved",
+          "pre_qualified" => false
+        },
+        "proposal_simulation" => %{
+          "financing_type" => "some financing_type",
+          "loan_requested_amount" => 12_000_000.00
+        }
+      }
+    }
+
+    @expected_proposal %Proposal{
+      sales_stage: nil,
+      lost_reason: nil,
+      id: @proposal_id,
+      status: "open",
+      blearning_lead_score: 987,
+      main_proponent: %Proponent{
+        id_validation_status: "some id_validation_status",
+        bacen_score: 515,
+        name: "some name",
+        email: "some@email.com",
+        mobile_phone_number: "some mobile_phone_number",
+        birthdate: ~D[1990-12-31],
+        cpf: "84931981100"
+      },
+      partner: %Partner{
+        partner_type: "some partner_type",
+        slug: "some slug"
+      },
+      credit_analysis: %CreditAnalysis{
+        warranty_region_status: "approved",
+        warranty_type_status: "approved",
+        warranty_value_status: "approved",
+        pre_qualified: false
+      },
+      proposal_simulation: %ProposalSimulation{
+        financing_type: "some financing_type",
+        loan_requested_amount: 12_000_000.00
+      }
+    }
+
     test "returns error when fails" do
       proposal_id = UUID.uuid4()
       proposals_url = "#{@base_url}/v1/proposals/#{proposal_id}"
@@ -128,17 +191,13 @@ defmodule HttpClients.UnderwriterTest do
     end
 
     test "returns a proposal" do
-      proposal_id = UUID.uuid4()
-      sales_stage = "open"
-      proposals_url = "#{@base_url}/v1/proposals/#{proposal_id}"
+      proposals_url = "#{@base_url}/v1/proposals/#{@proposal_id}"
 
       mock(fn %{method: :get, url: ^proposals_url} ->
-        proposal = %{"id" => proposal_id, "sales_stage" => sales_stage}
-        json(%{"data" => proposal}, status: 200)
+        json(@get_proposal_response, status: 200)
       end)
 
-      assert {:ok, %Proposal{id: ^proposal_id, sales_stage: ^sales_stage}} =
-               Underwriter.get_proposal(client(), proposal_id)
+      assert {:ok, @expected_proposal} = Underwriter.get_proposal(client(), @proposal_id)
     end
   end
 


### PR DESCRIPTION
**Why is this change necessary?**

- New fields need to be added to the underwriter API so we can qualify proposals

**How does it address the issue?**

- Adds the missing fields for qualification on Underwriter.Proposal

**Task card (link)**

- [SPRF-1249](https://bcredi.atlassian.net/browse/SPRF-1249)
