### PR TITLE
[SPRF-1318] fix HttpClients.Neurotech.check_identity/4 response when Receita Federal failed

### DIFF
--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -39,14 +39,11 @@ defmodule HttpClients.Neurotech do
     end
   end
 
-  defp check_identity_response(status) do
-    case status do
-      "APROVADO" -> {:ok, true}
-      "REPROVADO" -> {:ok, false}
-      "PENDENTE" -> {:ok, false}
-      _failed -> {:error, :failed}
-    end
-  end
+  defp check_identity_response(status)
+  defp check_identity_response("APROVADO"), do: {:ok, true}
+  defp check_identity_response("REPROVADO"), do: {:ok, false}
+  defp check_identity_response("PENDENTE"), do: {:ok, false}
+  defp check_identity_response(_failed), do: {:error, :failed}
 
   @spec compute_bacen_score(Tesla.Client.t(), Credentials.t(), Person.t(), integer(), Keyword.t()) ::
           {:ok, Score.t()} | {:error, any()}

--- a/lib/http_clients/neurotech.ex
+++ b/lib/http_clients/neurotech.ex
@@ -29,7 +29,7 @@ defmodule HttpClients.Neurotech do
 
     case Request.submit(client, request) do
       {:ok, %Tesla.Env{status: 200, body: %{"StatusCode" => "0100"}} = response} ->
-        {:ok, approved?(response.body["Result"]["Result"])}
+        check_identity_response(response.body["Result"]["Result"])
 
       {:ok, %Tesla.Env{} = response} ->
         {:error, response}
@@ -39,7 +39,14 @@ defmodule HttpClients.Neurotech do
     end
   end
 
-  defp approved?(status), do: status == "APROVADO"
+  defp check_identity_response(status) do
+    case status do
+      "APROVADO" -> {:ok, true}
+      "REPROVADO" -> {:ok, false}
+      "PENDENTE" -> {:ok, false}
+      _failed -> {:error, :failed}
+    end
+  end
 
   @spec compute_bacen_score(Tesla.Client.t(), Credentials.t(), Person.t(), integer(), Keyword.t()) ::
           {:ok, Score.t()} | {:error, any()}

--- a/test/http_clients/fixtures/neurotech.ex
+++ b/test/http_clients/fixtures/neurotech.ex
@@ -23,7 +23,16 @@ defmodule HttpClients.Fixtures.Neurotech do
   def check_identity_response(:pending) do
     %{
       "Result" => %{
-        "Result" => "PENDING"
+        "Result" => "PENDENTE"
+      },
+      "StatusCode" => "0100"
+    }
+  end
+
+  def check_identity_response(:failed) do
+    %{
+      "Result" => %{
+        "Result" => "FALHA"
       },
       "StatusCode" => "0100"
     }

--- a/test/http_clients/neurotech_test.exs
+++ b/test/http_clients/neurotech_test.exs
@@ -37,6 +37,15 @@ defmodule HttpClients.NeurotechTest do
                Neurotech.check_identity(client(), credentials(), person, @transaction_id)
     end
 
+    test "returns error when identity flow failed" do
+      response_body = check_identity_response(:failed)
+      mock(fn %{url: "/submit", method: :post} -> json(response_body) end)
+      person = %Neurotech.Person{birthdate: Date.utc_today()}
+
+      assert Neurotech.check_identity(client(), credentials(), person, @transaction_id) ==
+               {:error, :failed}
+    end
+
     test "returns error when the request fails" do
       mock(fn %{url: "/submit", method: :post} ->
         json(%{"errors" => "some reason"}, status: 404)


### PR DESCRIPTION
**Why is this change necessary?**

- To not disapprove a Proponent's identity when `Receita Federal` is down.

**How does it address the issue?**

- Fix `HttpClients.Neurotech.check_identity/4` response.

**Task card (link)**

- [SPRF-1318](https://bcredi.atlassian.net/browse/SPRF-1318)